### PR TITLE
Check for kong variable to support Konnect

### DIFF
--- a/kong/plugins/ddtrace/schema.lua
+++ b/kong/plugins/ddtrace/schema.lua
@@ -41,7 +41,7 @@ local validate_static_tags = function(tags)
 end
 
 local function allow_referenceable(field)
-    if kong.version_num >= 2008000 then
+    if kong and kong.version_num >= 2008000 then
         field.referenceable = true
     end
     return field


### PR DESCRIPTION
This verifies that kong variable exists when doing schema validation. 
This is needed to support Kong Konnect. 

There is an issue with this: https://github.com/DataDog/kong-plugin-ddtrace/issues/16

The main change is that when running in Konnect, the kong variable is unavailable, so the check can't run. 
There may be a better solution, but this is a quick solution. 