### PR TITLE
Skip version validation for Konnect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ luacov.stats.out
 luacov.report.out
 # exclude Pongo containerid file
 .containerid
+.DS_Store

--- a/kong/plugins/ddtrace/schema.lua
+++ b/kong/plugins/ddtrace/schema.lua
@@ -40,14 +40,15 @@ local validate_static_tags = function(tags)
     return true
 end
 
+-- make a field referenceable if kong version >= 2.8.0 and Konnect
 local function allow_referenceable(field)
-    if kong and kong.version_num >= 2008000 then
-        field.referenceable = true
+    -- assumption kong.version_num is not available in Konnect
+    if (not kong) or (kong and kong.version_num >= 2008000) then
+        field.referenceable = true -- kong version >= 2.8.0 or Konnect
     end
     return field
 end
 
--- make a field referenceable if kong version >= 2.8.0
 local resource_name_rule = Schema.define {
     type = "record",
     fields = {


### PR DESCRIPTION
This verifies that kong variable exists when doing schema validation. 
This is needed to support Kong Konnect. 

There is an issue with this: https://github.com/DataDog/kong-plugin-ddtrace/issues/16

The main change is that when running in Konnect, the kong variable is unavailable, so the check can't run. 
There may be a better solution, but this is a quick solution. 