### PR TITLE
Resolving #21, Enable adding custom trace spans from other plugins

### DIFF
--- a/kong/plugins/ddtrace/handler.lua
+++ b/kong/plugins/ddtrace/handler.lua
@@ -179,7 +179,7 @@ local function apply_resource_name_rules(uri, rules)
         end
         ::continue::
     end
-        
+
     return table.concat(fragments)
 end
 
@@ -418,7 +418,13 @@ function DatadogTraceHandler:log_p(conf) -- luacheck: ignore 212
     if conf and conf.include_credential and ngx_ctx.authenticated_credential then
         request_span:set_tag("kong.credential", ngx_ctx.authenticated_credential.id)
     end
-    tag_with_service_and_route(proxy_span)
+    if conf and conf.include_shared_traces and kong.ctx.shared.traces then
+      for k, v in pairs(kong.ctx.shared.traces) do
+        request_span:set_tag(k, v)
+      end
+    end
+
+  tag_with_service_and_route(proxy_span)
 
     proxy_span:finish(proxy_finish_mu * 1000LL)
     request_span:finish(request_finish_mu * 1000LL)

--- a/kong/plugins/ddtrace/handler.lua
+++ b/kong/plugins/ddtrace/handler.lua
@@ -2,7 +2,8 @@ local new_sampler = require "kong.plugins.ddtrace.sampler".new
 local new_trace_agent_writer = require "kong.plugins.ddtrace.agent_writer".new
 local new_span = require "kong.plugins.ddtrace.span".new
 local propagator = require "kong.plugins.ddtrace.propagation"
-
+local kong = kong
+local pairs = pairs
 local pcall = pcall
 local subsystem = ngx.config.subsystem
 local fmt = string.format
@@ -420,7 +421,11 @@ function DatadogTraceHandler:log_p(conf) -- luacheck: ignore 212
     end
     if conf and conf.include_shared_traces and kong.ctx.shared.traces then
       for k, v in pairs(kong.ctx.shared.traces) do
-        request_span:set_tag(k, v)
+        if type(v) ~= "table" then
+          request_span:set_tag(k, tostring(v))
+        else
+          kong.log.err("Can only add string tags to traces. Skipping tag: " .. k)
+        end
       end
     end
 

--- a/kong/plugins/ddtrace/schema.lua
+++ b/kong/plugins/ddtrace/schema.lua
@@ -71,6 +71,7 @@ return {
                 { resource_name_rule = { type = "array", elements = resource_name_rule } },
                 { initial_samples_per_second = { type = "integer", default = 100, gt = 0 } },
                 { initial_sample_rate = { type = "number", default = nil, between = {0, 1 } } },
+                { include_shared_traces = { type = "boolean", default = false, description = "Include all the key value pairs listed in kong.ctx.shared.traces variable as part of the request_span" } }
             },
         }, },
     },


### PR DESCRIPTION
This is a way to enable adding custom span tags to the DD traces as reported in [issue #21](https://github.com/DataDog/kong-plugin-ddtrace/issues/21)

The code brings the table exposes through kong.ctx.shared.traces and add the values to the request_span