### PR TITLE
Reimplement environment variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ The hostname or IP that will be used to connect to the agent.
 
 `--data 'config.agent_host=your-agent-address'`
 
-This value can use vault references. By default, the value of the environment variable `DD_AGENT_HOST` is used by resolving `vault://env/dd-agent-host`.
-When this variable is not set, the default is `localhost`.
+This value can also be set using the environment variable `DD_AGENT_HOST`. It can also be configured to use a vault reference.
 
-In Kubernetes helm chart deployments of Kong, the value can be passed in using a field reference.
+The default value is unset, and the effective value is "localhost".
+
+In Kubernetes helm chart deployments of Kong, the value can be passed in using an environment variable or vault reference.
 
 ```yaml
 env:
@@ -59,7 +60,6 @@ dblessConfig:
       - name: ddtrace
         config:
           service_name: kong-ddtrace
-          agent_host: "{vault://env/dd-agent-host}"
           environment: 'dev'
 ...
 ```
@@ -70,8 +70,9 @@ The URL that will be used to connect to the agent. The value should not include 
 
 `--data 'config.trace_agent_url=http://localhost:8126'`
 
-This value can use vault references. By default, the value of the environment variale `DD_TRACE_AGENT_URL` is used by resolving `vault://env/dd-trace-agent-url`.
-When this variable is not set, the default is `http://localhost:8126`.
+This value can also be set using the environment variable `DD_TRACE_AGENT_URL`. It can also be configured with a vault reference.
+
+The default value is unset, and the effective value is "http://localhost:8126".
 
 ### Agent Endpoint (deprecated)
 
@@ -80,7 +81,9 @@ This option will be deprecated in future releases.
 
 `--data config.agent_endpoint=http://localhost:8126/v0.4/traces'`
 
-This value can use vault references. The default value is nil.
+This can be configured with a vault references.
+
+The default value is unset, and the value is ignored if `agent_host` or `trace_agent_url` are configured.
 
 ### Service Name
 
@@ -88,8 +91,9 @@ The service name represents the application or component that is producing trace
 
 `--data 'config.service_name=your-preferred-name'`
 
-This value can use vault references. By default, the value of the environment variale `DD_SERVICE` is used by resolving `vault://env/dd-service`.
-When this variable is not set, the default is `kong`.
+This value can be set using the environment variable `DD_SERVICE`. It can also be configured with a vault reference.
+
+The default value is "kong"
 
 ### Environment
 
@@ -97,8 +101,10 @@ The environment is a larger grouping of related services, such as `prod`, `stagi
 
 `--data 'config.environment=prod'`
 
-This value can use vault references. By default, the value of the environment variale `DD_ENV` is used by resolving `vault://env/dd-env`.
-When this variable is not set, spans will not have an `environment` tag.
+This value can be set using the environment variable `DD_ENV`. It can also be configured with a vault reference.
+
+The default value is unset, and spans produced by the tracer will not have an "env" tag.
+
 
 ### Version
 
@@ -107,8 +113,9 @@ This is useful in both static deployments and CI/CD workflows.
 
 `--data 'config.version=1234'`
 
-This value can use vault references. By default, the value of the environment variale `DD_VERSION` is used by resolving `vault://env/dd-version`.
-When this variable is not set, spans will not have a `version` tag.
+This value can be set using the environment variable `DD_VERSION`. It can also be configured with a vault reference.
+
+The default value is unset, and spans produced by the tracer will not have a "version" tag.
 
 ### Sampling Controls
 

--- a/kong/plugins/ddtrace/agent_writer.lua
+++ b/kong/plugins/ddtrace/agent_writer.lua
@@ -7,23 +7,7 @@ local agent_writer_mt = {
     __index = agent_writer_methods,
 }
 
-local function new(conf, sampler, tracer_version)
-    -- traces_endpoint is determined by the configuration with this
-    -- order of precedence:
-    -- - use trace_agent_url if set
-    -- - use agent_host:agent_port if agent_host is set
-    -- - use agent_endpoint if set but warn that it is deprecated
-    -- - if nothing is set, default to http://localhost:8126/v0.4/traces
-    local traces_endpoint = string.format("http://localhost:%d/v0.4/traces", conf.trace_agent_port)
-    if conf.trace_agent_url then
-        traces_endpoint = conf.trace_agent_url .. "/v0.4/traces"
-    elseif conf.agent_host then
-        traces_endpoint = string.format("http://%s:%d/v0.4/traces", conf.agent_host, conf.trace_agent_port)
-    elseif conf.agent_endpoint then
-        kong.log.warn("agent_endpoint is deprecated. Please use trace_agent_url or agent_host instead.")
-        traces_endpoint = conf.agent_endpoint
-    end
-    kong.log.notice("traces will be sent to the agent at " .. traces_endpoint)
+local function new(traces_endpoint, sampler, tracer_version)
     return setmetatable({
         traces_endpoint = traces_endpoint,
         sampler = sampler,

--- a/kong/plugins/ddtrace/schema.lua
+++ b/kong/plugins/ddtrace/schema.lua
@@ -81,19 +81,18 @@ return {
         { config = {
             type = "record",
             fields = {
-                { service_name = allow_referenceable({ type = "string", required = true, default = "{vault://env/dd-service}" }, "kong") },
-                { environment = allow_referenceable({ type = "string", default = "{vault://env/dd-env}" }, nil) },
-                -- priority of values for agent address details are resolved in new_trace_agent_writer
-                { agent_host = allow_referenceable(typedefs.host({ default = "{vault://env/dd-agent-host}" }), "localhost") },
+                -- defaults are resolved in handler.lua
+                { service_name = allow_referenceable({ type = "string" }) },
+                { environment = allow_referenceable({ type = "string" }) },
+                { agent_host = allow_referenceable(typedefs.host()) },
                 { trace_agent_port = { type = "integer", default = 8126, gt = 0 } },
-                { trace_agent_url = allow_referenceable(typedefs.url({ default = "{vault://env/dd-trace-agent-url}" }), nil) },
-                { agent_endpoint = allow_referenceable(typedefs.url({ default = nil }), nil)},
-                { static_tags = { type = "array", elements = static_tag,
-                custom_validator = validate_static_tags } },
+                { trace_agent_url = allow_referenceable(typedefs.url()) },
+                { agent_endpoint = allow_referenceable(typedefs.url({ default = nil })) },
+                { static_tags = { type = "array", elements = static_tag, custom_validator = validate_static_tags } },
                 { resource_name_rule = { type = "array", elements = resource_name_rule } },
                 { initial_samples_per_second = { type = "integer", default = 100, gt = 0 } },
                 { initial_sample_rate = { type = "number", default = nil, between = {0, 1 } } },
-                { version = allow_referenceable({ type = "string", default = "{vault://env/dd-version}" }, nil) },
+                { version = allow_referenceable({ type = "string" }) },
             },
         }, },
     },


### PR DESCRIPTION
The earlier approach using `{vault://env/variable-name}` defaults for some values was not working as expected. This change still supports vault references, but has internal defaults to lookup and use environment variables instead.