### PR TITLE
feat: support 128-bit trace id

### DIFF
--- a/kong/plugins/ddtrace/agent_writer.lua
+++ b/kong/plugins/ddtrace/agent_writer.lua
@@ -33,10 +33,34 @@ local function new(conf, sampler, tracer_version)
     }, agent_writer_mt)
 end
 
+local function encode_span(span)
+    return encoder.pack({
+        type = span.type,
+        service = span.service,
+        name = span.name,
+        resource = span.resource,
+        trace_id = span.trace_id.low,
+        span_id = span.span_id,
+        parent_id = span.parent_id,
+        start = span.start,
+        sampling_priority = span.sampling_priority,
+        origin = span.origin,
+        meta = span.meta,
+        metrics = span.metrics,
+        error = span.error,
+    })
+end
+
 
 function agent_writer_methods:add(spans)
     local i = self.trace_segments_n + 1
-    self.trace_segments[i] = encoder.pack(spans)
+
+    local buffer = encoder.arrayheader(#spans)
+    for _, span in ipairs(spans) do
+        buffer = buffer .. encode_span(span)
+    end
+
+    self.trace_segments[i] = buffer
     self.trace_segments_n = i
 end
 

--- a/kong/plugins/ddtrace/handler.lua
+++ b/kong/plugins/ddtrace/handler.lua
@@ -209,7 +209,8 @@ if subsystem == "http" then
             name = "kong.plugin.ddtrace",
             start_us = ngx.ctx.KONG_PROCESSING_START * 1000000LL,
             -- TODO: decrease cardinality of path value
-            resource = method .. " " .. apply_resource_name_rules(path, conf.resource_name_rule)
+            resource = method .. " " .. apply_resource_name_rules(path, conf.resource_name_rule),
+            generate_128bit_trace_ids = conf.generate_128bit_trace_ids
         }
 
         local request_span = propagator.extract_or_create_span(req, span_options, conf.max_header_size)

--- a/kong/plugins/ddtrace/propagation.lua
+++ b/kong/plugins/ddtrace/propagation.lua
@@ -3,7 +3,7 @@ local new_span = require "kong.plugins.ddtrace.span".new
 
 local function extract_or_create_span(request, span_options, max_header_size)
     local trace_id, parent_id, sampling_priority, origin, propagation_tags, err = datadog.extract(request.get_header, max_header_size)
-    local span = new_span(span_options.service, span_options.name, span_options.resource, trace_id, nil, parent_id, span_options.start_us, sampling_priority, origin, nil)
+    local span = new_span(span_options.service, span_options.name, span_options.resource, trace_id, nil, parent_id, span_options.start_us, sampling_priority, origin, span_options.generate_128bit_trace_ids, nil)
     if propagation_tags then
         span:set_tags(propagation_tags)
     end

--- a/kong/plugins/ddtrace/sampler.lua
+++ b/kong/plugins/ddtrace/sampler.lua
@@ -79,7 +79,7 @@ end
 -- returns whether the span is sampled based on the max_id
 local function sampling_decision(span, max_id)
     -- not-ideal knuth hashing of trace ids
-    local hashed_trace_id = span.trace_id * 1111111111111111111ULL
+    local hashed_trace_id = span.trace_id.low * 1111111111111111111ULL
     if hashed_trace_id > max_id then
         return false
     end

--- a/kong/plugins/ddtrace/schema.lua
+++ b/kong/plugins/ddtrace/schema.lua
@@ -120,6 +120,7 @@ return {
                 { version = allow_referenceable({ type = "string", default = "{vault://env/dd-version}" }, nil) },
                 { header_tags = { type = "array", elements = header_tag, custom_validator = validate_header_tag } },
                 { max_header_size = { type = "integer", default = 512, between = {0, 512} } },
+                { generate_128bit_trace_ids = { type = "boolean", default = true } },
             },
         }, },
     },

--- a/spec/02_sampler_spec.lua
+++ b/spec/02_sampler_spec.lua
@@ -12,7 +12,7 @@ describe("trace sampler", function()
     it("default rate", function()
         local start_time = 1700000000000000000LL
         local duration = 100000000LL
-        local span = new_span("test_service", "test_name", "test_resource", nil, nil, nil, start_time, nil)
+        local span = new_span("test_service", "test_name", "test_resource", nil, nil, nil, start_time, nil, nil, false, nil)
         local sampler = new_sampler(10, nil)
         local sampled = sampler:sample(span)
         assert.is_true(sampled)
@@ -25,7 +25,7 @@ describe("trace sampler", function()
     it("is created with initial limits", function()
         local start_time = 1700000000000000000LL
         local duration = 100000000LL
-        local span = new_span("test_service", "test_name", "test_resource", nil, nil, nil, start_time, nil)
+        local span = new_span("test_service", "test_name", "test_resource", nil, nil, nil, start_time, nil, nil, false, nil)
         local sampler = new_sampler(10, 1.0)
         local sampled = sampler:sample(span)
         assert.is_true(sampled)
@@ -39,7 +39,7 @@ describe("trace sampler", function()
         local increment = 100000000LL -- 0.1s
         local sampler = new_sampler(3, 1.0)
         for i = 1, 10 do
-            local span = new_span("test_service", "test_name", "test_resource", nil, nil, nil, start_time, nil)
+            local span = new_span("test_service", "test_name", "test_resource", nil, nil, nil, start_time, nil, nil, false, nil)
             local sampled = sampler:sample(span)
             if i <= 3 then
                 assert.is_true(sampled)
@@ -66,7 +66,7 @@ describe("trace sampler", function()
          local limit_rule_and_sampled = 0
          local limit_rule_and_not_sampled = 0
          for i = 1, 100 do
-             local span = new_span("test_service", "test_name", "test_resource", nil, nil, nil, start_time, nil)
+             local span = new_span("test_service", "test_name", "test_resource", nil, nil, nil, start_time, nil, nil, false, nil)
              local sampled = sampler:sample(span)
              assert.equal(span.meta["_dd.p.dm"], "-3")
              if sampled then
@@ -93,7 +93,7 @@ describe("trace sampler", function()
         -- first two will be sampled, next two not sampled, and fifth one in new time interval,
         -- so effective rate should be 0.5
         for i = 1, 5 do
-            span = new_span("test_service", "test_name", "test_resource", nil, nil, nil, start_time, nil)
+            span = new_span("test_service", "test_name", "test_resource", nil, nil, nil, start_time, nil, nil, false, nil)
             sampler:sample(span)
             span:finish(start_time + duration)
             start_time = start_time + increment
@@ -104,7 +104,7 @@ describe("trace sampler", function()
         local start_time = 1700000000000000000LL
         local duration = 100000000LL
         local sampler = new_sampler(0, 1.0)
-        local span = new_span("test_service", "test_name", "test_resource", nil, nil, nil, start_time, nil)
+        local span = new_span("test_service", "test_name", "test_resource", nil, nil, nil, start_time, nil, nil, false, nil)
         sampler:sample(span)
         span:finish(start_time + duration)
         assert.equal(span.meta["_dd.p.dm"], "-3")
@@ -115,7 +115,7 @@ describe("trace sampler", function()
         local sampler = new_sampler(0, nil)
         local rates_applied = sampler:update_sampling_rates('{ "rate_by_service": { "service:test_service,env:": 0.1, "service:,env:": 1.0 } }')
         assert.is_true(rates_applied)
-        local span = new_span("test_service", "test_name", "test_resource", nil, nil, nil, start_time, nil)
+        local span = new_span("test_service", "test_name", "test_resource", nil, nil, nil, start_time, nil, nil, false, nil)
         sampler:sample(span)
         span:finish(start_time + duration)
         assert.equal(span.meta["_dd.p.dm"], "-1")

--- a/spec/03_propagation_spec.lua
+++ b/spec/03_propagation_spec.lua
@@ -10,7 +10,8 @@ local default_span_opts = {
     service = "kong",
     name = "kong.handle",
     start_us = 1708943277 * 1000000LL,
-    resource = "default_resource"
+    resource = "default_resource",
+    generate_128bit_trace_ids = true
 }
 
 local default_max_header_size = 512

--- a/spec/04_agent_writer_spec.lua
+++ b/spec/04_agent_writer_spec.lua
@@ -57,7 +57,7 @@ describe("agent_writer", function()
         local agent_writer = new_agent_writer({ agent_host = "datadog-agent", trace_agent_port = 8126 }, sampler, "test-version")
         local start_time = 1700000000000000000LL
         local duration = 100000000LL
-        local span = new_span("test_service", "test_name", "test_resource", nil, nil, nil, start_time, nil)
+        local span = new_span("test_service", "test_name", "test_resource", nil, nil, nil, start_time, nil, nil, false, nil)
         span:finish(start_time + duration)
         agent_writer:add({span})
         local ok = agent_writer:flush()


### PR DESCRIPTION
# Description
This PR add support for 128-bit trace id. 

Content:
- Generate 128-bit trace ids by default. This can be override with the new `generate_128bit_trace_ids` option.
- Propagation: inject datadog internal tags to HTTP Headers.
- Propagation: extract datadog internal tags from HTTP Headers.
- Add unit tests.