### PR TITLE
fix: environment variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ It was originally based on the [zipkin plugin](https://github.com/Kong/kong-plug
 
 ## Compatibility
 
-This plugin is compatible with Kong Gateway v2.x and v3.x.
-The oldest version tested is v2.0.5 and the newest is v3.2.2
+This plugin is compatible with Kong Gateway `v2.x` and `v3.x`.
+The oldest version tested is `v2.0.5` and the newest is `v3.6.1`
 
 ## Installation
 
@@ -39,30 +39,9 @@ The hostname or IP that will be used to connect to the agent.
 
 `--data 'config.agent_host=your-agent-address'`
 
-This value can use vault references. By default, the value of the environment variable `DD_AGENT_HOST` is used by resolving `vault://env/dd-agent-host`.
-When this variable is not set, the default is `localhost`.
+The default value is `localhost`.
 
-In Kubernetes helm chart deployments of Kong, the value can be passed in using a field reference.
-
-```yaml
-env:
-...
-  DD_AGENT_HOST:
-    valueFrom:
-      fieldRef:
-        fieldPath: status.hostIP
-...
-dblessConfig:
-  config:
-    _format_version: "2.1"
-    plugins:
-      - name: ddtrace
-        config:
-          service_name: kong-ddtrace
-          agent_host: "{vault://env/dd-agent-host}"
-          environment: 'dev'
-...
-```
+This value can also be set using the environment variable `DD_AGENT_HOST` and overrides any other specified value, including the default setting.
 
 ### Agent URL
 
@@ -70,8 +49,9 @@ The URL that will be used to connect to the agent. The value should not include 
 
 `--data 'config.trace_agent_url=http://localhost:8126'`
 
-This value can use vault references. By default, the value of the environment variale `DD_TRACE_AGENT_URL` is used by resolving `vault://env/dd-trace-agent-url`.
-When this variable is not set, the default is `http://localhost:8126`.
+The default value is `http://localhost:8126`.
+
+The value set through the environment variable `DD_TRACE_AGENT_URL` overrides any other specified value, including the default setting.
 
 ### Agent Endpoint (deprecated)
 
@@ -88,27 +68,23 @@ The service name represents the application or component that is producing trace
 
 `--data 'config.service_name=your-preferred-name'`
 
-This value can use vault references. By default, the value of the environment variale `DD_SERVICE` is used by resolving `vault://env/dd-service`.
-When this variable is not set, the default is `kong`.
+The value set through the environment variable `DD_SERVICE` overrides any other specified value, including the default setting.
 
 ### Environment
 
-The environment is a larger grouping of related services, such as `prod`, `staging` or `dev`.
+The environment is a larger grouping of related services, such as `prod`, `staging` or `dev`. By default, generated spans will not have an `environment` tag.
 
 `--data 'config.environment=prod'`
 
-This value can use vault references. By default, the value of the environment variale `DD_ENV` is used by resolving `vault://env/dd-env`.
-When this variable is not set, spans will not have an `environment` tag.
+The value set through the environment variable `DD_ENV` overrides any other specified value, including the default setting.
 
 ### Version
 
-The version is a user-defined value for tracking a application version, or a versioned combination of applications, configuration, and other assets.
-This is useful in both static deployments and CI/CD workflows.
+The version is a user-defined value for tracking a application version, or a versioned combination of applications, configuration, and other assets. By default, generated spans will not have a `version` tag.
 
 `--data 'config.version=1234'`
 
-This value can use vault references. By default, the value of the environment variale `DD_VERSION` is used by resolving `vault://env/dd-version`.
-When this variable is not set, spans will not have a `version` tag.
+The value set through the environment variable `DD_VERSION` overrides any other specified value, including the default setting.
 
 ### Sampling Controls
 
@@ -226,9 +202,9 @@ If the `DD_API_KEY` was correctly set, then the trace should appear at https://a
 
 ### Built-in Tests
 
-The built-in tests can be executed by running `pongo run`.
+The built-in tests can be executed by running `pongo run --no-datadog-agent`.
 
-A report for test coverage is produced when run with additional options: `pongo run -- --coverage`.
+A report for test coverage is produced when run with additional options: `pongo run --no-datadog-agent -- --coverage`.
 
 ## Issues and Incomplete features
 

--- a/kong/plugins/ddtrace/agent_writer.lua
+++ b/kong/plugins/ddtrace/agent_writer.lua
@@ -7,23 +7,10 @@ local agent_writer_mt = {
     __index = agent_writer_methods,
 }
 
-local function new(conf, sampler, tracer_version)
-    -- traces_endpoint is determined by the configuration with this
-    -- order of precedence:
-    -- - use trace_agent_url if set
-    -- - use agent_host:agent_port if agent_host is set
-    -- - use agent_endpoint if set but warn that it is deprecated
-    -- - if nothing is set, default to http://localhost:8126/v0.4/traces
-    local traces_endpoint = string.format("http://localhost:%d/v0.4/traces", conf.trace_agent_port)
-    if conf.trace_agent_url then
-        traces_endpoint = conf.trace_agent_url .. "/v0.4/traces"
-    elseif conf.agent_host then
-        traces_endpoint = string.format("http://%s:%d/v0.4/traces", conf.agent_host, conf.trace_agent_port)
-    elseif conf.agent_endpoint then
-        kong.log.warn("agent_endpoint is deprecated. Please use trace_agent_url or agent_host instead.")
-        traces_endpoint = conf.agent_endpoint
-    end
+local function new(agent_url, sampler, tracer_version)
+    local traces_endpoint = string.format("%s/v0.4/traces", agent_url)
     kong.log.notice("traces will be sent to the agent at " .. traces_endpoint)
+
     return setmetatable({
         traces_endpoint = traces_endpoint,
         sampler = sampler,

--- a/kong/plugins/ddtrace/handler.lua
+++ b/kong/plugins/ddtrace/handler.lua
@@ -32,7 +32,7 @@ end
 -- This timer runs in the background to flush traces for all instances of the plugin.
 -- Because of the way timers work in lua, this can only be initialized when there's an
 -- active request. This gets initialized on the first request this plugin handles.
-local agent_writer_timer
+local agent_writer_timer -- luacheck: ignore 231
 local sampler
 local header_tags
 local ddtrace_conf

--- a/spec/04_agent_writer_spec.lua
+++ b/spec/04_agent_writer_spec.lua
@@ -28,33 +28,10 @@ local new_sampler = require "kong.plugins.ddtrace.sampler".new
 local new_span = require "kong.plugins.ddtrace.span".new
 
 describe("agent_writer", function()
-    describe("configures the traces endpoint", function()
-        local sampler = new_sampler(100, 1.0)
-        it("priority #1 is trace_agent_url", function()
-            local conf = { trace_agent_url = "http://trace-agent-url:8126", agent_host = "agent-host", trace_agent_port = 8126, agent_endpoint = "http://agent-endpoint:8126/v0.4/traces" }
-            local agent_writer = new_agent_writer(conf, sampler, "test-version")
-            assert.equal("http://trace-agent-url:8126/v0.4/traces", agent_writer.traces_endpoint)
-        end)
-        it("priority #2 is agent_host", function()
-            local conf = { agent_host = "agent-host", trace_agent_port = 8126, agent_endpoint = "http://agent-endpoint:8126/v0.4/traces" }
-            local agent_writer = new_agent_writer(conf, sampler, "test-version")
-            assert.equal("http://agent-host:8126/v0.4/traces", agent_writer.traces_endpoint)
-        end)
-        it("priority #3 is agent_endpoint", function()
-            local conf = { trace_agent_port = 8126, agent_endpoint = "http://agent-endpoint:8126/v0.4/traces" }
-            local agent_writer = new_agent_writer(conf, sampler, "test-version")
-            assert.equal("http://agent-endpoint:8126/v0.4/traces", agent_writer.traces_endpoint)
-        end)
-        it("and defaults to localhost", function()
-            local conf = { trace_agent_port = 8126 }
-            local agent_writer = new_agent_writer(conf, sampler, "test-version")
-            assert.equal("http://localhost:8126/v0.4/traces", agent_writer.traces_endpoint)
-        end)
-    end)
-
     it("adds spans then flushes them", function()
         local sampler = new_sampler(100, 1.0)
-        local agent_writer = new_agent_writer({ agent_host = "datadog-agent", trace_agent_port = 8126 }, sampler, "test-version")
+        local agent_writer = new_agent_writer("http://datadog-agent:8126", sampler, "test-version")
+        assert.equal("http://datadog-agent:8126/v0.4/traces", agent_writer.traces_endpoint)
         local start_time = 1700000000000000000LL
         local duration = 100000000LL
         local span = new_span("test_service", "test_name", "test_resource", nil, nil, nil, start_time, nil, nil, false, nil)


### PR DESCRIPTION
# Description
This is a rework of #30:
> The earlier approach using {vault://env/variable-name} defaults for some values was not working as expected. This change still supports vault references, but has internal defaults to lookup and use environment variables instead

## TODO
- [x] Update README.md