### PR TITLE
feat: support W3C propagation headers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           kong_version: stable
           pongo_version: latest
-      - run: pongo run --no-datadog-agent --no-postgress --no-cassandra -- --coverage
+      - run: pongo run --no-datadog-agent --no-postgres --no-cassandra -- --coverage
       - name: Publish code coverage summary
         run: |
           beg=$( grep -n "Summary" < luacov.report.out | cut -d ':' -f1 )

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           kong_version: stable
           pongo_version: latest
-      - run: pongo run --no-datadog-agent -- --coverage
+      - run: pongo run --no-datadog-agent --no-postgress --no-cassandra -- --coverage
       - name: Publish code coverage summary
         run: |
           beg=$( grep -n "Summary" < luacov.report.out | cut -d ':' -f1 )

--- a/.pongo/datadog-agent.yml
+++ b/.pongo/datadog-agent.yml
@@ -8,6 +8,7 @@ services:
     - '/proc/:/host/proc/:ro'
     - '/sys/fs/cgroup/:/host/sys/fs/cgroup:ro'
     environment:
+    - DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT=0.0.0.0:4318
     - DD_API_KEY
     - DD_SITE
     networks:

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ The version is a user-defined value for tracking a application version, or a ver
 
 The value set through the environment variable `DD_VERSION` overrides any other specified value, including the default setting.
 
+### Propagation Styles
+
+TBD
+
 ### Sampling Controls
 
 Sampling of traces is required in environments with high traffic load to reduce the amount of trace data produced and ingested by Datadog.
@@ -174,6 +178,10 @@ When configuring a Kong plugin using `curl`, the `--data` values should be wrapp
 
 Additional details about regular expressions can be found in OpenResty documentation for [ngx.re.match](https://github.com/openresty/lua-nginx-module#ngxrematch) and [ngx.re.sub
 ](https://github.com/openresty/lua-nginx-module#ngxresub) which are used to apply the resource name rules.
+
+### Propagation Style
+
+TBD
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Specify propagation styles for extracting or injecting tracing headers
 To configure injection styles, set the `injection_propagation_styles` field:
 ```sh
 --data 'config.injection_propagation_styles[1]=datadog'
+```
 
 To configure extraction styles, use the `extraction_propagation_styles` field:
 ```sh

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ The value set through the environment variable `DD_VERSION` overrides any other 
 Specify propagation styles for extracting or injecting tracing headers
 
 To configure injection styles, set the `injection_propagation_styles` field:
-`--data 'config.injection_propagation_styles[1]=datadog'`
-
+```sh
+--data 'config.injection_propagation_styles[1]=datadog'
 
 To configure extraction styles, use the `extraction_propagation_styles` field:
 ```sh

--- a/README.md
+++ b/README.md
@@ -99,7 +99,21 @@ The value set through the environment variable `DD_VERSION` overrides any other 
 
 ### Propagation Styles
 
-TBD
+Specify propagation styles for extracting or injecting tracing headers
+
+To configure injection styles, set the `injection_propagation_styles` field:
+`--data 'config.injection_propagation_styles[1]=datadog'`
+
+
+To configure extraction styles, use the `extraction_propagation_styles` field:
+```sh
+--data 'config.extraction_propagation_styles[1]=datadog' \
+--data 'config.extraction_propagation_styles[2]=tracecontext'
+```
+
+Accepted values are either `datadog` or `tracecontext`.
+
+Values set with `DD_TRACE_PROPAGATION_STYLE_INJECT` or `DD_TRACE_PROPAGATION_STYLE_EXTRACT` override any other specified values.
 
 ### Sampling Controls
 
@@ -178,10 +192,6 @@ When configuring a Kong plugin using `curl`, the `--data` values should be wrapp
 
 Additional details about regular expressions can be found in OpenResty documentation for [ngx.re.match](https://github.com/openresty/lua-nginx-module#ngxrematch) and [ngx.re.sub
 ](https://github.com/openresty/lua-nginx-module#ngxresub) which are used to apply the resource name rules.
-
-### Propagation Style
-
-TBD
 
 ## Testing
 

--- a/kong/plugins/ddtrace/handler.lua
+++ b/kong/plugins/ddtrace/handler.lua
@@ -1,6 +1,6 @@
 local new_sampler = require("kong.plugins.ddtrace.sampler").new
 local new_trace_agent_writer = require("kong.plugins.ddtrace.agent_writer").new
-local propagator = require("kong.plugins.ddtrace.propagation")
+local new_propagator = require("kong.plugins.ddtrace.propagation").new
 local utils = require("kong.plugins.ddtrace.utils")
 
 local pcall = pcall
@@ -33,6 +33,7 @@ end
 -- Because of the way timers work in lua, this can only be initialized when there's an
 -- active request. This gets initialized on the first request this plugin handles.
 local agent_writer_timer -- luacheck: ignore 231
+local propagator
 local sampler
 local header_tags
 local ddtrace_conf
@@ -193,12 +194,17 @@ local function configure(conf)
         environment = get_env("DD_ENV") or conf.environment,
         version = get_env("DD_VERSION") or conf.version,
         agent_url = get_env("DD_TRACE_AGENT_URL") or conf.trace_agent_url or agent_url,
+        injection_propagation_styles = get_env("DD_TRACE_PROPAGATION_STYLE_INJECT")
+            or conf.injection_propagation_styles,
+        extraction_propagation_styles = get_env("DD_TRACE_PROPAGATION_STYLE_EXTRACT")
+            or conf.extraction_propagation_styles,
     }
 
     kong.log.info("DATADOG TRACER CONFIGURATION - " .. utils.dump(ddtrace_conf))
 
     agent_writer_timer = ngx.timer.every(2.0, flush_agent_writers)
     sampler = new_sampler(math.ceil(conf.initial_samples_per_second / ngx_worker_count), conf.initial_sample_rate)
+    propagator = new_propagator(ddtrace_conf.injection_propagation_styles, ddtrace_conf.extraction_propagation_styles)
 
     if conf and conf.header_tags then
         header_tags = utils.normalize_header_tags(conf.header_tags)
@@ -227,7 +233,7 @@ if subsystem == "http" then
             generate_128bit_trace_ids = conf.generate_128bit_trace_ids,
         }
 
-        local request_span = propagator.extract_or_create_span(req, span_options, conf.max_header_size)
+        local request_span = propagator:extract_or_create_span(req, span_options, conf.max_header_size)
 
         -- Set datadog tags
         if ddtrace_conf.environment then
@@ -333,7 +339,12 @@ if subsystem == "http" then
         local access_start = ngx_ctx.KONG_ACCESS_START and ngx_ctx.KONG_ACCESS_START * 1000 or ngx_now_mu()
         local proxy_span = get_or_add_proxy_span(datadog, access_start * 1000LL)
 
-        local err = propagator.inject(proxy_span, kong.service.request.set_header, conf.max_header_size)
+        local request = {
+            get_header = kong.request.get_header,
+            set_header = kong.service.request.set_header,
+        }
+
+        local err = propagator:inject(request, proxy_span, conf.max_header_size)
         if err then
             kong.log.error("Failed to inject trace (id: " .. proxy_span.trace_id .. "). Reason: " .. err)
         end

--- a/kong/plugins/ddtrace/propagation.lua
+++ b/kong/plugins/ddtrace/propagation.lua
@@ -82,9 +82,8 @@ function propagator:extract_or_create_span(request, span_options)
 end
 
 function propagator:inject(request, span)
-    -- TODO: handle error
-    for i = 1, #self.extraction_styles do
-        local style = self.extraction_styles[i]
+    for i = 1, #self.injection_styles do
+        local style = self.injection_styles[i]
         local injector = injectors[style]
         local err = injector(span, request, self.max_header_size)
         if err then

--- a/kong/plugins/ddtrace/propagation.lua
+++ b/kong/plugins/ddtrace/propagation.lua
@@ -17,17 +17,18 @@ local propagator_mt = {
     __index = propagator,
 }
 
-local function new(extraction_styles, injection_styles)
+local function new(extraction_styles, injection_styles, max_header_size)
     assert(extraction_styles ~= nil or type(extraction_styles) == "table")
     assert(injection_styles ~= nil or type(injection_styles) == "table")
 
     return setmetatable({
         extraction_styles = extraction_styles,
         injection_styles = injection_styles,
+        max_header_size = max_header_size,
     }, propagator_mt)
 end
 
-function propagator:extract_or_create_span(request, span_options, max_header_size)
+function propagator:extract_or_create_span(request, span_options)
     local err
     local trace_context
 
@@ -37,12 +38,16 @@ function propagator:extract_or_create_span(request, span_options, max_header_siz
         local style = self.extraction_styles[i]
         local extractor = extractors[style]
         local extracted
-        extracted, err = extractor(get_header, max_header_size)
+        extracted, err = extractor(get_header, self.max_header_size)
         if extracted then
             if not trace_context then
                 trace_context = extracted
+            elseif trace_context.trace_id ~= extracted.trace_id then
                 -- TODO: add span links
-                -- elseif trace_context.trace_id ~= extracted.trace_id then
+                local msg = "The extracted trace ID, obtained using "
+                    .. style
+                    .. " style, does not match the local trace ID"
+                kong.log.warn(msg)
             end
         end
     end
@@ -68,19 +73,23 @@ function propagator:extract_or_create_span(request, span_options, max_header_siz
     if trace_context and trace_context.propagation_tags then
         span:set_tags(trace_context.propagation_tags)
     end
+
     if err then
-        span:set_tag("ddtrace.propagation_error", err)
+        kong.log.warn("Propagation error: " .. err)
     end
 
     return span
 end
 
-function propagator:inject(request, span, max_header_size)
-    -- TODO: handle error AND put max_header_size in new
+function propagator:inject(request, span)
+    -- TODO: handle error
     for i = 1, #self.extraction_styles do
         local style = self.extraction_styles[i]
         local injector = injectors[style]
-        injector(span, request, max_header_size)
+        local err = injector(span, request, self.max_header_size)
+        if err then
+            kong.log.err("An error occurred while injecting a span (id: " .. span.span_id .. "). Reason: " .. err)
+        end
     end
 end
 

--- a/kong/plugins/ddtrace/propagation.lua
+++ b/kong/plugins/ddtrace/propagation.lua
@@ -1,9 +1,57 @@
 local datadog = require("kong.plugins.ddtrace.datadog_propagation")
+local w3c = require("kong.plugins.ddtrace.w3c_propagation")
 local new_span = require("kong.plugins.ddtrace.span").new
 
-local function extract_or_create_span(request, span_options, max_header_size)
-    local trace_id, parent_id, sampling_priority, origin, propagation_tags, err =
-        datadog.extract(request.get_header, max_header_size)
+local extractors = {
+    datadog = datadog.extract,
+    tracecontext = w3c.extract,
+}
+
+local injectors = {
+    datadog = datadog.inject,
+    tracecontext = w3c.inject,
+}
+
+local propagator = {}
+local propagator_mt = {
+    __index = propagator,
+}
+
+local function new(extraction_styles, injection_styles)
+    assert(extraction_styles ~= nil or type(extraction_styles) == "table")
+    assert(injection_styles ~= nil or type(injection_styles) == "table")
+
+    return setmetatable({
+        extraction_styles = extraction_styles,
+        injection_styles = injection_styles,
+    }, propagator_mt)
+end
+
+function propagator:extract_or_create_span(request, span_options, max_header_size)
+    local err
+    local trace_context
+
+    local get_header = request.get_header
+
+    for i = 1, #self.extraction_styles do
+        local style = self.extraction_styles[i]
+        local extractor = extractors[style]
+        local extracted
+        extracted, err = extractor(get_header, max_header_size)
+        if extracted then
+            if not trace_context then
+                trace_context = extracted
+                -- TODO: add span links
+                -- elseif trace_context.trace_id ~= extracted.trace_id then
+            end
+        end
+    end
+
+    local trace_id = trace_context and trace_context.trace_id
+    local parent_id = trace_context and trace_context.parent_id
+    local sampling_priority = trace_context and trace_context.sampling_priority
+    local origin = trace_context and trace_context.origin
+
     local span = new_span(
         span_options.service,
         span_options.name,
@@ -17,8 +65,8 @@ local function extract_or_create_span(request, span_options, max_header_size)
         span_options.generate_128bit_trace_ids,
         nil
     )
-    if propagation_tags then
-        span:set_tags(propagation_tags)
+    if trace_context and trace_context.propagation_tags then
+        span:set_tags(trace_context.propagation_tags)
     end
     if err then
         span:set_tag("ddtrace.propagation_error", err)
@@ -27,7 +75,15 @@ local function extract_or_create_span(request, span_options, max_header_size)
     return span
 end
 
+function propagator:inject(request, span, max_header_size)
+    -- TODO: handle error AND put max_header_size in new
+    for i = 1, #self.extraction_styles do
+        local style = self.extraction_styles[i]
+        local injector = injectors[style]
+        injector(span, request, max_header_size)
+    end
+end
+
 return {
-    extract_or_create_span = extract_or_create_span,
-    inject = datadog.inject,
+    new = new,
 }

--- a/kong/plugins/ddtrace/schema.lua
+++ b/kong/plugins/ddtrace/schema.lua
@@ -93,9 +93,10 @@ local function validate_propagation_style(styles)
     }
 
     for i = 1, #styles do
-        local found = allowed_styles[styles[i]]
+        local style = styles[i]
+        local found = allowed_styles[style]
         if not found then
-            return nil, "unexpected style"
+            return nil, string.format('unexpected style "%s". Only datadog, tracecontext styles are supported', style)
         end
     end
 

--- a/kong/plugins/ddtrace/schema.lua
+++ b/kong/plugins/ddtrace/schema.lua
@@ -81,6 +81,27 @@ end
 local deprecated_agent_endpoint =
     make_deprecated_config("agent_endpoint is deprecated. Please use trace_agent_url or agent_host instead")
 
+-- TODO: find a better way with kong.Schema interface
+local function validate_propagation_style(styles)
+    if type(styles) ~= "table" then
+        return nil, "expect a table"
+    end
+
+    local allowed_styles = {
+        datadog = 1,
+        tracecontext = 1,
+    }
+
+    for i = 1, #styles do
+        local found = allowed_styles[styles[i]]
+        if not found then
+            return nil, "unexpected style"
+        end
+    end
+
+    return true
+end
+
 return {
     name = "ddtrace",
     fields = {
@@ -108,6 +129,22 @@ return {
                     { header_tags = { type = "array", elements = header_tag, custom_validator = validate_header_tag } },
                     { max_header_size = { type = "integer", default = 512, between = { 0, 512 } } },
                     { generate_128bit_trace_ids = { type = "boolean", default = true } },
+                    {
+                        injection_propagation_styles = {
+                            type = "array",
+                            elements = { type = "string" },
+                            custom_validator = validate_propagation_style,
+                            default = { "datadog", "tracecontext" },
+                        },
+                    },
+                    {
+                        extraction_propagation_styles = {
+                            type = "array",
+                            elements = { type = "string" },
+                            custom_validator = validate_propagation_style,
+                            default = { "datadog", "tracecontext" },
+                        },
+                    },
                     -- Deprecated:
                     { agent_endpoint = { type = "string", custom_validator = deprecated_agent_endpoint } },
                 },

--- a/kong/plugins/ddtrace/w3c_propagation.lua
+++ b/kong/plugins/ddtrace/w3c_propagation.lua
@@ -1,0 +1,200 @@
+local parse_uint64 = require("kong.plugins.ddtrace.utils").parse_uint64
+local join_table = require("kong.plugins.ddtrace.utils").join_table
+local band = bit.band
+local btohex = bit.tohex
+local re_match = ngx.re.match
+-- local re_gmatch = ngx.re.gmatch
+
+local traceparent_format = "([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})"
+
+local function startswith(s, pattern)
+    return s:sub(1, #pattern) == pattern
+end
+
+local function parse_datadog_tracestate(tracestate)
+    -- TODO:
+    --   * support tracestate as an array.
+    --   * there's a limit of 32 elements. If limit is reached the right
+    --     most will not be processed.
+    local result = {}
+    local dd_state = string.match(tracestate, "dd=(.*)")
+    if not dd_state then
+        return result, nil
+    end
+
+    -- local m, err = re_match(dd_state, "([a-z0-9]+):([a-z0-9]+)", "ijo")
+    -- local it, err = re_gmatch(dd_state, "([a-z0-9]+):([a-z0-9]+)", "ijo")
+    -- if not it then
+    --     return nil
+    -- end
+    --
+    -- while true do
+    --     local m, err = it()
+    --     local k = m[1]
+    --     local v = m[2]
+    for k, v in string.gmatch(dd_state, "([%w-._]+):([%w-._]+)") do
+        if k == "s" then
+            local sampling, err = tonumber(v)
+            if err then
+                return result, err
+            end
+            result["sampling_priority"] = sampling
+        elseif k == "o" then
+            result["origin"] = v
+        elseif k == "p" then
+            result["parent_id"] = v
+        elseif k == "t.dm" then
+            local m, err = re_match(v, "-[0-9]+", "ajo")
+            if not m then
+                return result, err
+            end
+
+            result["_dd.p.dm"] = v
+        end
+    end
+
+    return result, nil
+end
+
+local function extract(get_header, _)
+    local traceparent = get_header("traceparent")
+    if not traceparent then
+        return nil, "not traceparent header found"
+    end
+
+    if not startswith(traceparent, "00") or #traceparent < 55 then
+        return nil, "could not decode traceparent"
+    end
+
+    -- NOTE:
+    --   * traceid is 16-byte hex-encoded (128b)
+    --   * parentid is 8-byte hex-encoded (64b)
+    --   * trace_flags is 8-byte hex-encoded and bit-field
+    local m, err = re_match(traceparent, traceparent_format, "ajo")
+    if err then
+        return nil, err
+    end
+
+    local hex_trace_id, parent_id, trace_flags = table.unpack(m, 2) -- luacheck: ignore 143
+    if hex_trace_id == 0 then
+        return nil, "invalid trace_id"
+    end
+    if parent_id == 0 then
+        return nil, "invalid parent_id"
+    end
+
+    local trace_id = { high = 0, low = 0 }
+    trace_id.high, err = parse_uint64(string.sub(hex_trace_id, 1, 16), 16)
+    if err then
+        return nil, "could not parse trace_id: " .. err
+    end
+    trace_id.low, err = parse_uint64(string.sub(hex_trace_id, 17, 32), 16)
+    if err then
+        return nil, "could not parse trace_id: " .. err
+    end
+
+    parent_id, err = parse_uint64(parent_id, 16)
+    if err then
+        return nil, "could not parse parent_id: " .. err
+    end
+
+    trace_flags, err = parse_uint64(trace_flags, 16)
+    if err then
+        return nil, "could not parse trace_flags: " .. err
+    end
+
+    -- tracestate
+    local dd_state = {}
+    local dd_tags = {}
+    local tracestate = get_header("tracestate")
+    if tracestate then
+        dd_state, err = parse_datadog_tracestate(tracestate)
+        if err then
+            kong.log.warning(err)
+        end
+    end
+
+    dd_tags["_dd.p.dm"] = dd_state["_dd.p.dm"]
+
+    local sampling_priority = 0 -- luacheck: ignore 311
+    local is_sampled = band(trace_flags, 0x01) > 0
+
+    local extracted_sampling = dd_state.sampling_priority
+    if is_sampled then
+        if not extracted_sampling or extracted_sampling <= 0 then
+            sampling_priority = 1
+            dd_tags["_dd.p.dm"] = "-0" --< DEFAULT
+        else
+            sampling_priority = extracted_sampling
+        end
+    else
+        if not extracted_sampling or extracted_sampling > 0 then
+            sampling_priority = 0
+        else
+            sampling_priority = extracted_sampling
+        end
+    end
+
+    return {
+        trace_id = trace_id,
+        parent_id = parent_id,
+        sampling_priority = sampling_priority,
+        origin = dd_state["origin"],
+        tags = dd_tags,
+    },
+        nil
+end
+
+local function inject(span, request, _)
+    local get_header = request.get_header
+    local set_header = request.set_header
+
+    local trace_id = btohex(span.trace_id.high or 0, 16) .. btohex(span.trace_id.low, 16)
+    local parent_id = btohex(span.span_id, 16)
+    local trace_flags = "00"
+    if span.sampling_priority > 0 then
+        trace_flags = "01"
+    end
+
+    local states = {}
+    if span.sampling_priority then
+        table.insert(states, "s:" .. span.sampling_priority)
+    end
+    if span.origin then
+        table.insert(states, "o:" .. span.origin)
+    end
+
+    local root = (span.root ~= nil and span.root) or span
+    assert(root ~= nil)
+
+    if root.meta then
+        for k, v in pairs(root.meta) do
+            local propagation_key = string.match(k, "_dd%.p%.(.*)")
+            if propagation_key then
+                table.insert(states, "t." .. propagation_key .. ":" .. v)
+            end
+        end
+    end
+
+    -- NOTE: not ideal to always rebuild the dd state as it is not forward compatible
+    -- but I plan to use `dd-trace-cpp` soon, which should fix that issue.
+    local dd_state = "dd=" .. join_table(";", states)
+
+    local tracestate = get_header("tracestate") or ""
+    tracestate = string.gsub(tracestate, ",?dd=[%w-._:;]+", "")
+    if #tracestate > 0 then
+        tracestate = dd_state .. "," .. tracestate
+    else
+        tracestate = dd_state
+    end
+
+    local traceparent = string.format("00-%s-%s-%s", trace_id, parent_id, trace_flags)
+    assert(#traceparent == 55)
+    set_header("traceparent", traceparent)
+    set_header("tracestate", tracestate)
+end
+
+return {
+    extract = extract,
+    inject = inject,
+}

--- a/spec/03_propagation_spec.lua
+++ b/spec/03_propagation_spec.lua
@@ -3,7 +3,7 @@ local new_propagator = require("kong.plugins.ddtrace.propagation").new
 
 _G.kong = {
     log = {
-        warn = function(s) end,
+        warn = function() end,
     },
 }
 
@@ -29,16 +29,15 @@ describe("trace propagation", function()
     describe("extraction", function()
         it("empty headers generates a new span", function()
             local styles = { "datadog", "tracecontext" }
-            local propagator = new_propagator(styles, styles)
+            local propagator = new_propagator(styles, styles, default_max_header_size)
             local request = { get_header = function(s) end }
-            local span = propagator:extract_or_create_span(request, default_span_opts, default_max_header_size)
+            local span = propagator:extract_or_create_span(request, default_span_opts)
 
             assert.is_not_nil(span)
-            -- assert.is_nil(span.meta["ddtrace.propagation_error"])
         end)
 
         it("respect style", function()
-            local datadog_propagator = new_propagator({ "datadog" }, { "datadog" })
+            local datadog_propagator = new_propagator({ "datadog" }, { "datadog" }, default_max_header_size)
             local request = {
                 get_header = make_getter({
                     traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
@@ -46,15 +45,18 @@ describe("trace propagation", function()
                 }),
             }
 
-            local span = datadog_propagator:extract_or_create_span(request, default_span_opts, default_max_header_size)
+            local span = datadog_propagator:extract_or_create_span(request, default_span_opts)
             local expected_trace_id = { high = 0x4bf92f3577b34da6ULL, low = 0xa3ce929d0e0e4736ULL }
             local expected_parent_id = 0x00f067aa0ba902b7ULL
             assert.are_not.same(expected_trace_id, span.trace_id)
             assert.are_not.same(expected_parent_id, span.parent_id)
 
-            local tracecontext_propagator = new_propagator({ "tracecontext" }, { "tracecontext" })
-            local extracted_span =
-                tracecontext_propagator:extract_or_create_span(request, default_span_opts, default_max_header_size)
+            local tracecontext_propagator = new_propagator(
+                { "tracecontext" },
+                { "tracecontext" },
+                default_max_header_size
+            )
+            local extracted_span = tracecontext_propagator:extract_or_create_span(request, default_span_opts)
             assert.same(expected_trace_id, extracted_span.trace_id)
             assert.same(expected_parent_id, extracted_span.parent_id)
         end)
@@ -62,7 +64,7 @@ describe("trace propagation", function()
         it("extraction style order is respected", function()
             -- NOTE: datadog and tracecontext header do not match -> datadog propagation must be use
             local datadog_first = { "datadog", "tracecontext" }
-            local multi_propagator = new_propagator(datadog_first, datadog_first)
+            local multi_propagator = new_propagator(datadog_first, datadog_first, default_max_header_size)
             local request = {
                 get_header = make_getter({
                     traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
@@ -72,7 +74,7 @@ describe("trace propagation", function()
                 }),
             }
 
-            local span = multi_propagator:extract_or_create_span(request, default_span_opts, default_max_header_size)
+            local span = multi_propagator:extract_or_create_span(request, default_span_opts)
 
             local expected_trace_id = { high = nil, low = 12345678901234567890ULL }
             local expected_parent_id = 9876543210987654321ULL
@@ -94,7 +96,7 @@ describe("trace propagation", function()
 
         it("multiple styles", function()
             local all_styles = { "datadog", "tracecontext" }
-            local multi_propagator = new_propagator(all_styles, all_styles)
+            local multi_propagator = new_propagator(all_styles, all_styles, default_max_header_size)
 
             local span = new_span(
                 default_span_opts.service,
@@ -110,7 +112,7 @@ describe("trace propagation", function()
                 nil
             )
 
-            multi_propagator:inject(request, span, default_max_header_size)
+            multi_propagator:inject(request, span)
 
             assert.is_string(headers["traceparent"])
             assert.is_string(headers["tracestate"])

--- a/spec/03_propagation_spec.lua
+++ b/spec/03_propagation_spec.lua
@@ -1,10 +1,19 @@
-local propagator = require("kong.plugins.ddtrace.propagation")
+local new_span = require("kong.plugins.ddtrace.span").new
+local new_propagator = require("kong.plugins.ddtrace.propagation").new
 
 _G.kong = {
     log = {
         warn = function(s) end,
     },
 }
+
+local function make_getter(headers)
+    local function getter(header)
+        return headers[header]
+    end
+
+    return getter
+end
 
 local default_span_opts = {
     service = "kong",
@@ -19,15 +28,94 @@ local default_max_header_size = 512
 describe("trace propagation", function()
     describe("extraction", function()
         it("empty headers generates a new span", function()
+            local styles = { "datadog", "tracecontext" }
+            local propagator = new_propagator(styles, styles)
             local request = { get_header = function(s) end }
-            local span = propagator.extract_or_create_span(request, default_span_opts, default_max_header_size)
+            local span = propagator:extract_or_create_span(request, default_span_opts, default_max_header_size)
 
             assert.is_not_nil(span)
-            assert.is_nil(span.meta["ddtrace.propagation_error"])
+            -- assert.is_nil(span.meta["ddtrace.propagation_error"])
+        end)
+
+        it("respect style", function()
+            local datadog_propagator = new_propagator({ "datadog" }, { "datadog" })
+            local request = {
+                get_header = make_getter({
+                    traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+                    tracestate = "fizz=buzz:fizzbuzz,dd=s:2;o:rum;p:00f067aa0ba902b7;t.dm:-5",
+                }),
+            }
+
+            local span = datadog_propagator:extract_or_create_span(request, default_span_opts, default_max_header_size)
+            local expected_trace_id = { high = 0x4bf92f3577b34da6ULL, low = 0xa3ce929d0e0e4736ULL }
+            local expected_parent_id = 0x00f067aa0ba902b7ULL
+            assert.are_not.same(expected_trace_id, span.trace_id)
+            assert.are_not.same(expected_parent_id, span.parent_id)
+
+            local tracecontext_propagator = new_propagator({ "tracecontext" }, { "tracecontext" })
+            local extracted_span =
+                tracecontext_propagator:extract_or_create_span(request, default_span_opts, default_max_header_size)
+            assert.same(expected_trace_id, extracted_span.trace_id)
+            assert.same(expected_parent_id, extracted_span.parent_id)
+        end)
+
+        it("extraction style order is respected", function()
+            -- NOTE: datadog and tracecontext header do not match -> datadog propagation must be use
+            local datadog_first = { "datadog", "tracecontext" }
+            local multi_propagator = new_propagator(datadog_first, datadog_first)
+            local request = {
+                get_header = make_getter({
+                    traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+                    tracestate = "fizz=buzz:fizzbuzz,dd=s:2;o:rum;p:00f067aa0ba902b7;t.dm:-5",
+                    ["x-datadog-trace-id"] = "12345678901234567890",
+                    ["x-datadog-parent-id"] = "9876543210987654321",
+                }),
+            }
+
+            local span = multi_propagator:extract_or_create_span(request, default_span_opts, default_max_header_size)
+
+            local expected_trace_id = { high = nil, low = 12345678901234567890ULL }
+            local expected_parent_id = 9876543210987654321ULL
+            assert.same(expected_trace_id, span.trace_id)
+            assert.same(expected_parent_id, span.parent_id)
         end)
     end)
 
-    describe("injection", function()
-        pending("Until another propagation mechanism is implemented")
+    describe("inject", function()
+        local headers = {}
+        local request = {
+            get_header = function(k)
+                return nil
+            end,
+            set_header = function(key, value)
+                headers[key] = value
+            end,
+        }
+
+        it("multiple styles", function()
+            local all_styles = { "datadog", "tracecontext" }
+            local multi_propagator = new_propagator(all_styles, all_styles)
+
+            local span = new_span(
+                default_span_opts.service,
+                default_span_opts.name,
+                default_span_opts.resource,
+                nil,
+                nil,
+                nil,
+                default_span_opts.start_us,
+                1,
+                "test-origin",
+                default_span_opts.generate_128bit_trace_ids,
+                nil
+            )
+
+            multi_propagator:inject(request, span, default_max_header_size)
+
+            assert.is_string(headers["traceparent"])
+            assert.is_string(headers["tracestate"])
+            assert.is_string(headers["x-datadog-trace-id"])
+            assert.is_string(headers["x-datadog-parent-id"])
+        end)
     end)
 end)

--- a/spec/06_datadog_propagation_spec.lua
+++ b/spec/06_datadog_propagation_spec.lua
@@ -367,7 +367,7 @@ describe("trace propagation", function()
             end,
         }
 
-        local extracted, err = extract_datadog(request.get_header, 512)
+        local extracted, _ = extract_datadog(request.get_header, 512)
         assert.is_not_nil(extracted)
 
         local start_us = 1711027189 * 100000000LL

--- a/spec/07_w3c_propagation_spec.lua
+++ b/spec/07_w3c_propagation_spec.lua
@@ -1,0 +1,367 @@
+local extract_w3c = require("kong.plugins.ddtrace.w3c_propagation").extract
+local inject_w3c = require("kong.plugins.ddtrace.w3c_propagation").inject
+local new_span = require("kong.plugins.ddtrace.span").new
+local bhex = bit.tohex
+
+local function make_getter(headers)
+    local function getter(header)
+        return headers[header]
+    end
+
+    return getter
+end
+
+describe("extract w3c", function()
+    it("no w3c headers", function()
+        local get_header = make_getter({})
+        local extracted, err = extract_w3c(get_header, get_header)
+        assert.is_nil(extracted)
+        assert.is_not_nil(err)
+    end)
+
+    describe("traceparent", function()
+        it("ill-formated", function()
+            -- TODO: use fuzzy
+            local get_header = make_getter({
+                traceparent = "no-good-format",
+            })
+
+            local extracted, err = extract_w3c(get_header, get_header)
+            assert.is_nil(extracted)
+            assert.is_not_nil(err)
+        end)
+
+        it("unsupported version", function()
+            local get_header = make_getter({
+                traceparent = "01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+            })
+
+            local extracted, err = extract_w3c(get_header, get_header)
+            assert.is_nil(extracted)
+            assert.is_not_nil(err)
+        end)
+
+        it("valid", function()
+            local get_header = make_getter({
+                traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+            })
+
+            local extracted, err = extract_w3c(get_header, _)
+            assert.is_nil(err)
+
+            local expected = {
+                trace_id = { high = 0x4bf92f3577b34da6ULL, low = 0xa3ce929d0e0e4736ULL },
+                parent_id = 0x00f067aa0ba902b7ULL,
+                tags = { ["_dd.p.dm"] = "-0" },
+                sampling_priority = 1,
+            }
+            assert.same(expected, extracted)
+        end)
+    end)
+
+    describe("tracestate", function()
+        describe("extract valid datadog state", function()
+            local get_header = make_getter({
+                traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+                tracestate = "fizz=buzz:fizzbuzz,dd=s:2;o:rum;p:00f067aa0ba902b7;t.dm:-5",
+            })
+            local extracted, err = extract_w3c(get_header, _)
+            assert.is_nil(err)
+
+            local expected = {
+                trace_id = { high = 0x4bf92f3577b34da6ULL, low = 0xa3ce929d0e0e4736ULL },
+                parent_id = 0x00f067aa0ba902b7ULL,
+                origin = "rum",
+                tags = { ["_dd.p.dm"] = "-5" },
+                sampling_priority = 2,
+            }
+            assert.same(expected, extracted)
+        end)
+        describe("sampling priority logic", function()
+            describe("trace is sampled", function()
+                it("extracted datadog sampling_priority is >0 -> use it", function()
+                    local get_header = make_getter({
+                        traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+                        tracestate = "bar=over:dd,dd=s:2",
+                    })
+                    local extracted, err = extract_w3c(get_header, _)
+                    assert.is_nil(err)
+
+                    local expected = {
+                        trace_id = { high = 0x4bf92f3577b34da6ULL, low = 0xa3ce929d0e0e4736ULL },
+                        parent_id = 0x00f067aa0ba902b7ULL,
+                        tags = {},
+                        sampling_priority = 2,
+                    }
+                    assert.same(expected, extracted)
+                end)
+                it("datadog sampling_priority is absent -> keep", function()
+                    local get_header = make_getter({
+                        traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+                        tracestate = "bar=over:dd",
+                    })
+                    local extracted, err = extract_w3c(get_header, _)
+                    assert.is_nil(err)
+
+                    local expected = {
+                        trace_id = { high = 0x4bf92f3577b34da6ULL, low = 0xa3ce929d0e0e4736ULL },
+                        parent_id = 0x00f067aa0ba902b7ULL,
+                        tags = { ["_dd.p.dm"] = "-0" },
+                        sampling_priority = 1,
+                    }
+                    assert.same(expected, extracted)
+                end)
+                it("extracted datadog sampling_priority is <= 0 -> keep", function()
+                    local get_header = make_getter({
+                        traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+                        tracestate = "dd=s:-5;bar=over:dd",
+                    })
+                    local extracted, err = extract_w3c(get_header, _)
+                    assert.is_nil(err)
+
+                    local expected = {
+                        trace_id = { high = 0x4bf92f3577b34da6ULL, low = 0xa3ce929d0e0e4736ULL },
+                        parent_id = 0x00f067aa0ba902b7ULL,
+                        tags = { ["_dd.p.dm"] = "-0" },
+                        sampling_priority = 1,
+                    }
+                    assert.same(expected, extracted)
+                end)
+            end)
+            describe("trace is not sampled", function()
+                it("extracted datadog sampling_priority is >0 -> drop", function()
+                    local get_header = make_getter({
+                        traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00",
+                        tracestate = "bar=over:dd,dd=s:3",
+                    })
+                    local extracted, err = extract_w3c(get_header, _)
+                    assert.is_nil(err)
+
+                    local expected = {
+                        trace_id = { high = 0x4bf92f3577b34da6ULL, low = 0xa3ce929d0e0e4736ULL },
+                        parent_id = 0x00f067aa0ba902b7ULL,
+                        tags = {},
+                        sampling_priority = 0,
+                    }
+                    assert.same(expected, extracted)
+                end)
+                it("datadog sampling_priority is absent -> drop", function()
+                    local get_header = make_getter({
+                        traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00",
+                        tracestate = "dd=foo:bar,vendor=cake:lie",
+                    })
+                    local extracted, err = extract_w3c(get_header, _)
+                    assert.is_nil(err)
+
+                    local expected = {
+                        trace_id = { high = 0x4bf92f3577b34da6ULL, low = 0xa3ce929d0e0e4736ULL },
+                        parent_id = 0x00f067aa0ba902b7ULL,
+                        tags = {},
+                        sampling_priority = 0,
+                    }
+                    assert.same(expected, extracted)
+                end)
+                it("extracted datadog sampling_priority is <= 0 -> use it", function()
+                    local get_header = make_getter({
+                        traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00",
+                        tracestate = "dd=s:-2;foo:bar,vendor=cake:lie",
+                    })
+                    local extracted, err = extract_w3c(get_header, _)
+                    assert.is_nil(err)
+
+                    local expected = {
+                        trace_id = { high = 0x4bf92f3577b34da6ULL, low = 0xa3ce929d0e0e4736ULL },
+                        parent_id = 0x00f067aa0ba902b7ULL,
+                        tags = {},
+                        sampling_priority = -2,
+                    }
+                    assert.same(expected, extracted)
+                end)
+            end)
+        end)
+    end)
+end)
+
+describe("w3c inject", function()
+    local headers = {}
+    local request = {
+        get_header = function(header)
+            return nil
+        end,
+        set_header = function(key, value)
+            headers[key] = value
+        end,
+    }
+    local start_us = 1711119544 * 100000000LL
+    it("64-bit trace ID", function()
+        local span = new_span(
+            "kong-test",
+            "w3c-injection-64b-trace-id",
+            "injection-resource",
+            nil,
+            nil,
+            nil,
+            start_us,
+            2,
+            "kong",
+            false,
+            nil
+        )
+
+        inject_w3c(span, request, 512)
+
+        local expected_traceparent =
+            string.format("00-0000000000000000%s-%s-01", bhex(span.trace_id.low), bhex(span.span_id))
+        assert.equal(55, #headers["traceparent"])
+        assert.equal(expected_traceparent, headers["traceparent"])
+        assert.equal("dd=s:2;o:kong", headers["tracestate"])
+    end)
+
+    it("128-bit trace ID", function()
+        local span = new_span(
+            "kong-test",
+            "w3c-injection-128b-trace-id",
+            "injection-resource",
+            nil,
+            nil,
+            nil,
+            start_us,
+            2,
+            "kong",
+            true,
+            nil
+        )
+
+        inject_w3c(span, request, 512)
+
+        local expected_traceparent =
+            string.format("00-%s%s-%s-01", bhex(span.trace_id.high), bhex(span.trace_id.low), bhex(span.span_id))
+        local expected_tracestate = string.format("dd=s:2;o:kong;t.tid:%s", bhex(span.trace_id.high))
+        assert.equal(55, #headers["traceparent"])
+        assert.equal(expected_traceparent, headers["traceparent"])
+        assert.equal(expected_tracestate, headers["tracestate"])
+    end)
+end)
+
+describe("w3c propagation round trip", function()
+    it("dd state is first in tracestate", function()
+        local out_headers = {}
+        local request = {
+            get_header = make_getter({
+                traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+                tracestate = "dd=s:2;o:rum;t.tid:4bf92f3577b34da6",
+            }),
+            set_header = function(key, value)
+                out_headers[key] = value
+            end,
+        }
+
+        local extracted, err = extract_w3c(request.get_header, _)
+        assert.is_not_nil(extracted)
+
+        local start_us = 1711027573 * 100000000LL
+        local span = new_span(
+            "w3c-test",
+            "round-trip",
+            "resource",
+            extracted.trace_id,
+            nil,
+            extracted.parent_id,
+            start_us,
+            extracted.sampling_priority,
+            extracted.origin,
+            true,
+            nil
+        )
+        assert.is_not_nil(span)
+        span:set_tags(extracted.tags)
+
+        inject_w3c(span, request, 512)
+
+        local expected_traceparent = string.format("00-4bf92f3577b34da6a3ce929d0e0e4736-%s-01", bhex(span.span_id))
+        local expected_tracestate = "dd=s:2;o:rum;t.tid:4bf92f3577b34da6"
+
+        assert.equal(expected_traceparent, out_headers["traceparent"])
+        assert.equal(expected_tracestate, out_headers["tracestate"])
+    end)
+
+    it("dd state between vendors -> set dd state first", function()
+        local out_headers = {}
+        local request = {
+            get_header = make_getter({
+                traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+                tracestate = "vendor=k1:v1;k2:v2,dd=s:2;o:rum;t.tid:4bf92f3577b34da6,vendor2=k1:v1;k2:v2",
+            }),
+            set_header = function(key, value)
+                out_headers[key] = value
+            end,
+        }
+
+        local extracted, err = extract_w3c(request.get_header, _)
+        assert.is_not_nil(extracted)
+
+        local start_us = 1711027573 * 100000000LL
+        local span = new_span(
+            "w3c-test",
+            "round-trip",
+            "resource",
+            extracted.trace_id,
+            nil,
+            extracted.parent_id,
+            start_us,
+            extracted.sampling_priority,
+            extracted.origin,
+            true,
+            nil
+        )
+        assert.is_not_nil(span)
+        span:set_tags(extracted.tags)
+
+        inject_w3c(span, request, 512)
+
+        local expected_traceparent = string.format("00-4bf92f3577b34da6a3ce929d0e0e4736-%s-01", bhex(span.span_id))
+        local expected_tracestate = "dd=s:2;o:rum;t.tid:4bf92f3577b34da6,vendor=k1:v1;k2:v2,vendor2=k1:v1;k2:v2"
+        assert.equal(expected_traceparent, out_headers["traceparent"])
+        assert.equal(expected_tracestate, out_headers["tracestate"])
+    end)
+
+    it("dd state is at the end -> set dd state first", function()
+        local out_headers = {}
+        local request = {
+            get_header = make_getter({
+                traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+                tracestate = "vendor=k1:v1;k2:v2,dd=s:2;o:rum;t.tid:4bf92f3577b34da6",
+            }),
+            set_header = function(key, value)
+                out_headers[key] = value
+            end,
+        }
+
+        local extracted, err = extract_w3c(request.get_header, _)
+        assert.is_not_nil(extracted)
+
+        local start_us = 1711027573 * 100000000LL
+        local span = new_span(
+            "w3c-test",
+            "round-trip",
+            "resource",
+            extracted.trace_id,
+            nil,
+            extracted.parent_id,
+            start_us,
+            extracted.sampling_priority,
+            extracted.origin,
+            true,
+            nil
+        )
+        assert.is_not_nil(span)
+        span:set_tags(extracted.tags)
+
+        inject_w3c(span, request, 512)
+
+        local expected_traceparent = string.format("00-4bf92f3577b34da6a3ce929d0e0e4736-%s-01", bhex(span.span_id))
+        local expected_tracestate = "dd=s:2;o:rum;t.tid:4bf92f3577b34da6,vendor=k1:v1;k2:v2"
+        assert.equal(expected_traceparent, out_headers["traceparent"])
+        assert.equal(expected_tracestate, out_headers["tracestate"])
+    end)
+end)

--- a/spec/07_w3c_propagation_spec.lua
+++ b/spec/07_w3c_propagation_spec.lua
@@ -11,12 +11,14 @@ local function make_getter(headers)
     return getter
 end
 
+local unused_max_header_size = 255
+
 describe("extract w3c", function()
     it("no w3c headers", function()
         local get_header = make_getter({})
         local extracted, err = extract_w3c(get_header, get_header)
+        assert.is_nil(err)
         assert.is_nil(extracted)
-        assert.is_not_nil(err)
     end)
 
     describe("traceparent", function()
@@ -46,7 +48,7 @@ describe("extract w3c", function()
                 traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
             })
 
-            local extracted, err = extract_w3c(get_header, _)
+            local extracted, err = extract_w3c(get_header, unused_max_header_size)
             assert.is_nil(err)
 
             local expected = {
@@ -65,7 +67,7 @@ describe("extract w3c", function()
                 traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
                 tracestate = "fizz=buzz:fizzbuzz,dd=s:2;o:rum;p:00f067aa0ba902b7;t.dm:-5",
             })
-            local extracted, err = extract_w3c(get_header, _)
+            local extracted, err = extract_w3c(get_header, unused_max_header_size)
             assert.is_nil(err)
 
             local expected = {
@@ -84,7 +86,7 @@ describe("extract w3c", function()
                         traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
                         tracestate = "bar=over:dd,dd=s:2",
                     })
-                    local extracted, err = extract_w3c(get_header, _)
+                    local extracted, err = extract_w3c(get_header, unused_max_header_size)
                     assert.is_nil(err)
 
                     local expected = {
@@ -100,7 +102,7 @@ describe("extract w3c", function()
                         traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
                         tracestate = "bar=over:dd",
                     })
-                    local extracted, err = extract_w3c(get_header, _)
+                    local extracted, err = extract_w3c(get_header, unused_max_header_size)
                     assert.is_nil(err)
 
                     local expected = {
@@ -116,7 +118,7 @@ describe("extract w3c", function()
                         traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
                         tracestate = "dd=s:-5;bar=over:dd",
                     })
-                    local extracted, err = extract_w3c(get_header, _)
+                    local extracted, err = extract_w3c(get_header, unused_max_header_size)
                     assert.is_nil(err)
 
                     local expected = {
@@ -134,7 +136,7 @@ describe("extract w3c", function()
                         traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00",
                         tracestate = "bar=over:dd,dd=s:3",
                     })
-                    local extracted, err = extract_w3c(get_header, _)
+                    local extracted, err = extract_w3c(get_header, unused_max_header_size)
                     assert.is_nil(err)
 
                     local expected = {
@@ -150,7 +152,7 @@ describe("extract w3c", function()
                         traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00",
                         tracestate = "dd=foo:bar,vendor=cake:lie",
                     })
-                    local extracted, err = extract_w3c(get_header, _)
+                    local extracted, err = extract_w3c(get_header, unused_max_header_size)
                     assert.is_nil(err)
 
                     local expected = {
@@ -166,7 +168,7 @@ describe("extract w3c", function()
                         traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00",
                         tracestate = "dd=s:-2;foo:bar,vendor=cake:lie",
                     })
-                    local extracted, err = extract_w3c(get_header, _)
+                    local extracted, err = extract_w3c(get_header, unused_max_header_size)
                     assert.is_nil(err)
 
                     local expected = {
@@ -256,8 +258,9 @@ describe("w3c propagation round trip", function()
             end,
         }
 
-        local extracted, err = extract_w3c(request.get_header, _)
+        local extracted, err = extract_w3c(request.get_header, unused_max_header_size)
         assert.is_not_nil(extracted)
+        assert.is_nil(err)
 
         local start_us = 1711027573 * 100000000LL
         local span = new_span(
@@ -297,7 +300,8 @@ describe("w3c propagation round trip", function()
             end,
         }
 
-        local extracted, err = extract_w3c(request.get_header, _)
+        local extracted, err = extract_w3c(request.get_header, unused_max_header_size)
+        assert.is_nil(err)
         assert.is_not_nil(extracted)
 
         local start_us = 1711027573 * 100000000LL
@@ -337,7 +341,8 @@ describe("w3c propagation round trip", function()
             end,
         }
 
-        local extracted, err = extract_w3c(request.get_header, _)
+        local extracted, err = extract_w3c(request.get_header, unused_max_header_size)
+        assert.is_nil(err)
         assert.is_not_nil(extracted)
 
         local start_us = 1711027573 * 100000000LL


### PR DESCRIPTION
# Description 
- Enable OTLP Ingestion on Pongo's agent container.
- Add W3C injection/extraction propagation headers.
- Add configurable propagation styles. For now, only `datadog` and `tracecontext` are supported.
- Revise README.md to include updated configurations for propagation.
- Add new unit tests for W3C propagation headers.

# How to test
```yaml
_format_version: "3.0"
_transform: true

services:
- name: service-a
  url: http://localhost:8000/bar
  plugins:
  - name: ddtrace
    config:
      service_name: service-a
      agent_host: datadog-agent
  routes:
  - name: my-route-a
    paths:
    - /foo

- name: service-b
  url: http://httpbin.org/headers
  plugins:
  - name: opentelemetry
    config:
      endpoint: http://datadog-agent:4318/v1/traces
      resource_attributes:
        service.name: service-b
  routes:
  - name: my-route-b
    paths:
    - /bar
```

Run: `curl -i http://localhost:8000/foo`

Result:
<img width="1057" alt="Screenshot 2024-03-22 at 13 30 36" src="https://github.com/DataDog/kong-plugin-ddtrace/assets/204994/75d9b5f2-aadb-4c3c-99f7-8d4e9ab272c7">

# TODO:
- [ ] Self code review
- [ ] README.md