### PR TITLE
fix: error message attempt to call field 'warning' in w3c_propagation.lua

### DIFF
--- a/kong/plugins/ddtrace/w3c_propagation.lua
+++ b/kong/plugins/ddtrace/w3c_propagation.lua
@@ -101,7 +101,7 @@ local function extract(get_header, _)
     if tracestate then
         dd_state, err = parse_datadog_tracestate(tracestate)
         if err then
-            kong.log.warning(err)
+            kong.log.warn(err)
         end
     end
 


### PR DESCRIPTION
This is to address https://github.com/DataDog/kong-plugin-ddtrace/issues/48

I do not know much of `lua` but I did run `pongo run --no-datadog-agent` and it passed the test.