### PR TITLE
fix: ngx.re.match usage in w3c_propagation.lua

### DIFF
--- a/spec/07_w3c_propagation_spec.lua
+++ b/spec/07_w3c_propagation_spec.lua
@@ -43,6 +43,16 @@ describe("extract w3c", function()
             assert.is_not_nil(err)
         end)
 
+        it("bad format", function()
+            local get_header = make_getter({
+                traceparent = "00-ysjbsgwcpqmrahmydynyllupquotexmvzogsvvhfwyxxlmlkbgegekd",
+            })
+
+            local extracted, err = extract_w3c(get_header, get_header)
+            assert.is_nil(extracted)
+            assert.is_not_nil(err)
+        end)
+
         it("valid", function()
             local get_header = make_getter({
                 traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",


### PR DESCRIPTION
# Description
A customer spotted errors and warnings in their logs. Such as:
> 2024/04/03 04:06:31 [error] 2389#0: *773 [kong] handler.lua:379 [ddtrace] tracing error in DatadogTraceHandler:body_filter: ...l/share/lua/5.1/kong/plugins/ddtrace/w3c_propagation.lua:67: bad argument [#1](https://datadog.zendesk.com/agent/tickets/1) to 'unpack' (table expected, got nil), client: <REDACTED>

This PR fix `ngx.re.match` usage. I suspected `ngx.re.match` to return an error when there's no match but the err field is reserved for errors related to the regex engine. When there's no match, the first field is `nil`.

Contains:
- Fix `ngx.re.match` usage.
- Improve error messages.
- Add regression test. 