### PR TITLE
fix: header tag normalization

### DIFF
--- a/kong/plugins/ddtrace/utils.lua
+++ b/kong/plugins/ddtrace/utils.lua
@@ -51,8 +51,12 @@ local function normalize_header_tags(header_tags)
     local normalized = {}
 
     for i = 1, #header_tags do
-        local tag = header_tags[i].tag
+        local tag = header_tags[i].tag or ""
         local header = header_tags[i].header
+
+        if not header then
+            goto continue
+        end
 
         local norm_header = string.lower(string.gsub(header, "%s+", ""))
         if #norm_header == 0 then

--- a/spec/05_utils_spec.lua
+++ b/spec/05_utils_spec.lua
@@ -27,6 +27,9 @@ describe("utils.normalize_headers_tag", function()
     end)
     it("tag", function()
         local header_tags = {
+            { header = nil, tag = nil },
+            { header = nil, tag = "foobar" },
+            { header = "lorem", tag = nil },
             { header = "ConTeNt-Type", tag = "" },
             { header = "D!ata__d/o!g", tag = "_dd.header" },
             { header = "foo", tag = " " },
@@ -35,11 +38,12 @@ describe("utils.normalize_headers_tag", function()
 
         local norm_header_tags = utils.normalize_header_tags(header_tags)
 
-        assert.equal(count_table(norm_header_tags), 4)
+        assert.equal(count_table(norm_header_tags), 5)
         assert.same(norm_header_tags["content-type"], { normalized = true, value = "content-type" })
         assert.same(norm_header_tags["d_ata__d_o_g"], { normalized = false, value = "_dd.header" })
         assert.same(norm_header_tags["foo"], { normalized = true, value = "foo" })
         assert.same(norm_header_tags["bar"], { normalized = false, value = "mytag" })
+        assert.same(norm_header_tags["lorem"], { normalized = true, value = "lorem" })
     end)
 end)
 


### PR DESCRIPTION
# Description
An empty or `nil` tag when using `config.header_tags` was generating an error and preventing tracing. This commit correctly handle `nil` value for the tag field.

Resolves #59.

## Changes
  - Add tests.
  - Update normalization algorithm.