### PR TITLE
fix: proper Trace ID comparison

### DIFF
--- a/kong/plugins/ddtrace/utils.lua
+++ b/kong/plugins/ddtrace/utils.lua
@@ -128,10 +128,20 @@ local function join_table(separator, table)
     return result
 end
 
+local function trace_id_equals(a, b)
+    return a.low == b.low and a.high == b.high
+end
+
+local function trace_id_str(trace_id)
+    return "high: " .. tostring(trace_id.high) .. ", low: " .. tostring(trace_id.low)
+end
+
 return {
     concat = concat,
     dump = dump,
     join_table = join_table,
     normalize_header_tags = normalize_header_tags,
     parse_uint64 = parse_uint64,
+    trace_id_equals = trace_id_equals,
+    trace_id_str = trace_id_str,
 }


### PR DESCRIPTION
Previously, Trace IDs were being compared using the `~=` (not equal) operator, which is not suitable for Lua tables. This led to incorrect evaluation, resulting in false positive. As a consequence, logs were unnecessarily spammed when a request contained mutliple tracing contexts.

This commit resolves the issue by implementing a proper table comparison for Trace IDs.