### PR TITLE
Change DATADOG TRACER CONFIGURATION to debug log to reduce log noise.

### DIFF
--- a/kong/plugins/ddtrace/handler.lua
+++ b/kong/plugins/ddtrace/handler.lua
@@ -217,7 +217,7 @@ local function configure(conf)
         extraction_propagation_styles = conf.extraction_propagation_styles,
     }
 
-    kong.log.info("DATADOG TRACER CONFIGURATION - " .. utils.dump(ddtrace_conf))
+    kong.log.debug("DATADOG TRACER CONFIGURATION - " .. utils.dump(ddtrace_conf))
 
     agent_writer_timer = ngx.timer.every(2.0, flush_agent_writers)
     sampler = new_sampler(math.ceil(conf.initial_samples_per_second / ngx_worker_count), conf.initial_sample_rate)


### PR DESCRIPTION
Seeing large error.log files in kong due to the DATADOG TRACER CONFIGURATION log line being info level. This seems more appropriate as debug.

Addresses #77 