### PR TITLE
feat: add option to disable startup log

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -28,6 +28,7 @@ Configuration can be set either through the plugin configuration field or enviro
 | `intial_samples_per_second` | | Maximum number of traces allowed to be submitted per second | `v0.0.1` | `number` | `100` |
 | `resource_name_rule` | | Replace matching resources to lower the cardinality on resource names | `v0.0.1` | `array[rule] with rule = {match=str, replacement=str}]` | `nil` |
 | `header_tags` |  | Set HTTP Headers as root tags | `v0.2.0` | `array[header_tag] with header_tag = {header=str, tag=str}]` | `nil` |
+| `startup_log` | `DD_TRACE_STARTUP_LOGS` | Log the tracer configuration once the tracer is fully initialized and every time there's a config update | `v0.2.3` | `boolean` | `true` |
 
 ## Sampling Controls
 

--- a/kong/plugins/ddtrace/schema.lua
+++ b/kong/plugins/ddtrace/schema.lua
@@ -154,6 +154,7 @@ return {
                             default = { "datadog", "tracecontext" },
                         },
                     },
+                    { startup_log = { type = "boolean", default = true } },
                     -- Deprecated:
                     { agent_endpoint = { type = "string", custom_validator = deprecated_agent_endpoint } },
                 },

--- a/kong/plugins/ddtrace/utils.lua
+++ b/kong/plugins/ddtrace/utils.lua
@@ -136,6 +136,10 @@ local function trace_id_str(trace_id)
     return "high: " .. tostring(trace_id.high) .. ", low: " .. tostring(trace_id.low)
 end
 
+local function is_truthy(v)
+    return v and v == "1" or v == "true" or v == "yes"
+end
+
 return {
     concat = concat,
     dump = dump,
@@ -144,4 +148,5 @@ return {
     parse_uint64 = parse_uint64,
     trace_id_equals = trace_id_equals,
     trace_id_str = trace_id_str,
+    is_truthy = is_truthy,
 }

--- a/spec/05_utils_spec.lua
+++ b/spec/05_utils_spec.lua
@@ -55,3 +55,23 @@ describe("utils.concat", function()
         assert.same(utils.concat("Datadog", ", "), "Datadog")
     end)
 end)
+
+describe("utils.is_truthy", function()
+    it("cases", function()
+        local test_cases = {
+            { input = nil, expected = false },
+            { input = "", expected = false },
+            { input = "false", expected = false },
+            { input = "no", expected = false },
+            { input = "0", expected = false },
+            { input = "anything", expected = false },
+            { input = "1", expected = true },
+            { input = "true", expected = true },
+            { input = "yes", expected = true },
+        }
+
+        for _, case in ipairs(test_cases) do
+            assert.same(case.expected, utils.is_truthy(case.input))
+        end
+    end)
+end)


### PR DESCRIPTION
Changes:
  - Document the new configuration field for controlling startup log behavior.
  - Update the configure function to prevent unnecessary reconfiguration when the configuration remains unchanged.

Resolves #77