### PR TITLE
fix: trace id mismatch

### DIFF
--- a/kong/plugins/ddtrace/w3c_propagation.lua
+++ b/kong/plugins/ddtrace/w3c_propagation.lua
@@ -81,8 +81,8 @@ local function extract(get_header, _)
         return nil, "0 is an invalid parent ID"
     end
 
-    local high = nil
-    local low = nil
+    local high
+    local low
 
     high, err = parse_uint64(string.sub(hex_trace_id, 1, 16), 16)
     if err then

--- a/kong/plugins/ddtrace/w3c_propagation.lua
+++ b/kong/plugins/ddtrace/w3c_propagation.lua
@@ -81,14 +81,15 @@ local function extract(get_header, _)
         return nil, "0 is an invalid parent ID"
     end
 
-    local trace_id = { high = 0, low = 0 }
+    local high = nil
+    local low = nil
 
-    trace_id.high, err = parse_uint64(string.sub(hex_trace_id, 1, 16), 16)
+    high, err = parse_uint64(string.sub(hex_trace_id, 1, 16), 16)
     if err then
         return nil, "failed to parse trace ID: " .. err
     end
 
-    trace_id.low, err = parse_uint64(string.sub(hex_trace_id, 17, 32), 16)
+    low, err = parse_uint64(string.sub(hex_trace_id, 17, 32), 16)
     if err then
         return nil, "failed to parse trace ID: " .. err
     end
@@ -137,7 +138,7 @@ local function extract(get_header, _)
     end
 
     return {
-        trace_id = trace_id,
+        trace_id = { high = high, low = low },
         parent_id = parent_id,
         sampling_priority = sampling_priority,
         origin = dd_state["origin"],

--- a/spec/01-unit-tests/03_propagation_spec.lua
+++ b/spec/01-unit-tests/03_propagation_spec.lua
@@ -1,9 +1,12 @@
 local new_span = require("kong.plugins.ddtrace.span").new
 local new_propagator = require("kong.plugins.ddtrace.propagation").new
 
+local last_warning
 _G.kong = {
     log = {
-        warn = function() end,
+        warn = function(msg)
+            last_warning = msg
+        end,
     },
 }
 
@@ -80,6 +83,40 @@ describe("trace propagation", function()
             local expected_parent_id = 9876543210987654321ULL
             assert.same(expected_trace_id, span.trace_id)
             assert.same(expected_parent_id, span.parent_id)
+        end)
+
+        it("64-bit and 128-bit match", function()
+            local datadog_first = { "datadog", "tracecontext" }
+            local multi_propagator = new_propagator(datadog_first, datadog_first, default_max_header_size)
+            local request = {
+                get_header = make_getter({
+                    traceparent = "00-0000000000000000a3ce929d0e0e4736-00f067aa0ba902b7-01",
+                    tracestate = "fizz=buzz:fizzbuzz,dd=s:2;o:rum;p:00f067aa0ba902b7;t.dm:-5",
+                    ["x-datadog-trace-id"] = "11803532876627986230",
+                    ["x-datadog-parent-id"] = "67667974448284343",
+                }),
+            }
+
+            last_warning = nil
+            local _ = multi_propagator:extract_or_create_span(request, default_span_opts)
+            assert.is_nil(last_warning)
+        end)
+
+        it("mismatch trace ID log a warning", function()
+            local datadog_first = { "datadog", "tracecontext" }
+            local multi_propagator = new_propagator(datadog_first, datadog_first, default_max_header_size)
+            local request = {
+                get_header = make_getter({
+                    traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+                    tracestate = "fizz=buzz:fizzbuzz,dd=s:2;o:rum;p:00f067aa0ba902b7;t.dm:-5",
+                    ["x-datadog-trace-id"] = "12345678901234567890",
+                    ["x-datadog-parent-id"] = "9876543210987654321",
+                }),
+            }
+
+            last_warning = nil
+            local _ = multi_propagator:extract_or_create_span(request, default_span_opts)
+            assert.is_not_nil(last_warning)
         end)
     end)
 

--- a/spec/01-unit-tests/03_propagation_spec.lua
+++ b/spec/01-unit-tests/03_propagation_spec.lua
@@ -76,7 +76,7 @@ describe("trace propagation", function()
 
             local span = multi_propagator:extract_or_create_span(request, default_span_opts)
 
-            local expected_trace_id = { high = nil, low = 12345678901234567890ULL }
+            local expected_trace_id = { high = 0, low = 12345678901234567890ULL }
             local expected_parent_id = 9876543210987654321ULL
             assert.same(expected_trace_id, span.trace_id)
             assert.same(expected_parent_id, span.parent_id)

--- a/spec/01-unit-tests/06_datadog_propagation_spec.lua
+++ b/spec/01-unit-tests/06_datadog_propagation_spec.lua
@@ -44,7 +44,7 @@ describe("trace propagation", function()
             assert.is_nil(err)
             assert.is_not_nil(extracted)
 
-            local expected_trace_id = { high = nil, low = 12345678901234567890ULL }
+            local expected_trace_id = { high = 0, low = 12345678901234567890ULL }
             assert.same(expected_trace_id, extracted.trace_id)
             assert.equal(9876543210987654321ULL, extracted.parent_id)
             assert.equal(1, extracted.sampling_priority)


### PR DESCRIPTION
## Description
Some 128-bit w3c trace IDs in the wild contain a zero-padded 64-bit portion. This commit sets the default high part of the trace ID to 0, ensuring the check passes correctly.

## TODO next week ('cause it's the weekend 🕺)
- [x] Write unit tests.  

Resolves #83