### PR TITLE
feat: add macrobenchmark CI jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,13 @@
+stages:
+  - benchmarks
+
+macrobenchmarks:
+  stage: benchmarks
+  needs: []
+  trigger:
+    include: .gitlab/macrobenchmarks.yml
+  allow_failure: true
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: always
+    - when: manual

--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -1,0 +1,75 @@
+stages:
+  - macrobenchmarks
+
+variables:
+  MACROBENCHMARKS_CI_IMAGE: registry.ddbuild.io/ci/benchmarking-platform:kong-gateway
+
+.macrobenchmarks:
+  stage: macrobenchmarks
+  needs: []
+  tags: ["runner:apm-k8s-same-cpu"]
+  timeout: 1h
+  # retry:
+  #   max: 2
+  #   when:
+  #     - unknown_failure
+  #     - data_integrity_failure
+  #     - runner_system_failure
+  #     - scheduler_failure
+  #     - api_failure
+  when: on_success
+  image: $MACROBENCHMARKS_CI_IMAGE
+  script: |
+    git clone --branch kong https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
+    bp-runner bp-runner.yml --debug
+  artifacts:
+    name: "artifacts"
+    when: always
+    paths:
+      - platform/artifacts/
+    expire_in: 3 months
+  variables:
+    # Benchmark's env variables. Modify to tweak benchmark parameters.
+    # K6_OPTIONS_WARMUP_RATE: 40
+    # K6_OPTIONS_WARMUP_DURATION: 1m
+    # K6_OPTIONS_WARMUP_GRACEFUL_STOP: 0s
+    # K6_OPTIONS_WARMUP_PRE_ALLOCATED_VUS: 4
+    # K6_OPTIONS_WARMUP_MAX_VUS: 4
+
+    # K6_OPTIONS_NORMAL_OPERATION_RATE: 40
+    # K6_OPTIONS_NORMAL_OPERATION_DURATION: 5m
+    # K6_OPTIONS_NORMAL_OPERATION_GRACEFUL_STOP: 1m
+    # K6_OPTIONS_NORMAL_OPERATION_PRE_ALLOCATED_VUS: 4
+    # K6_OPTIONS_NORMAL_OPERATION_MAX_VUS: 4
+
+    # K6_OPTIONS_HIGH_LOAD_RATE: 500
+    # K6_OPTIONS_HIGH_LOAD_DURATION: 1m
+    # K6_OPTIONS_HIGH_LOAD_GRACEFUL_STOP: 30s
+    # K6_OPTIONS_HIGH_LOAD_PRE_ALLOCATED_VUS: 4
+    # K6_OPTIONS_HIGH_LOAD_MAX_VUS: 4
+
+    # Gitlab and BP specific env vars. Do not modify.
+    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
+
+  # Workaround: Currently we're not running the benchmarks on every PR, but GitHub still shows them as pending.
+  # By marking the benchmarks as allow_failure, this should go away. (This workaround should be removed once the
+  # benchmarks get changed to run on every PR)
+  # allow_failure: true
+
+baseline:
+  extends: .macrobenchmarks
+  variables:
+    CONTEXT: baseline
+    DDTRACE_VERSION: release
+
+tracing-release:
+  extends: .macrobenchmarks
+  variables:
+    CONTEXT: tracing
+    DDTRACE_VERSION: release
+
+tracing-head:
+  extends: .macrobenchmarks
+  variables:
+    CONTEXT: tracing
+    DDTRACE_VERSION: 265f099467c26984d6fab61abf55ca655ea40ed6

--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -7,7 +7,7 @@ variables:
 .macrobenchmarks:
   stage: macrobenchmarks
   needs: []
-  tags: ["runner:apm-k8s-same-cpu"]
+  tags: ["runner:apm-k8s-tweaked-metal"]
   timeout: 1h
   # retry:
   #   max: 2


### PR DESCRIPTION
[Set up kong-plugin-ddtrace benchmarks](https://datadoghq.atlassian.net/browse/APMSP-1885)

Add macrobenchmark CI jobs.

Benchmarks can be run through kong-plugin-ddtrace's CI: https://gitlab.ddbuild.io/DataDog/apm-reliability/kong-plugin-ddtrace/-/jobs/898800777