### PR TITLE
fix: blocking streaming responses

### DIFF
--- a/kong/plugins/ddtrace/handler.lua
+++ b/kong/plugins/ddtrace/handler.lua
@@ -271,13 +271,13 @@ local function access(conf)
     ctx.proxy_span = proxy_span
 end
 
-local function response(_)
+local function header_filter(_)
     local now = time_ns() * 1LL
     local ngx_ctx = ngx.ctx
 
     local ctx = kong.ctx.plugin
     if ctx.proxy_span == nil then
-        error("proxy span missing during the response phase")
+        error('proxy span missing during the "header_filter" phase')
     end
 
     local span = ctx.proxy_span
@@ -389,12 +389,12 @@ function DatadogTraceHandler:access(conf)
     end
 end
 
-function DatadogTraceHandler:response(conf)
+function DatadogTraceHandler:header_filter(conf)
     if subsystem ~= "http" then
         return
     end
 
-    local ok, message = pcall(response, conf)
+    local ok, message = pcall(header_filter, conf)
     if not ok then
         kong.log.err("tracing error in DatadogTraceHandler:response: ", message)
     end


### PR DESCRIPTION
## Description

In version `v0.2.3`, we introduced a [response handler](https://docs.konghq.com/gateway/latest/plugin-development/custom-logic/#available-contexts) to enable accurate measurement of proxy request latency. However, this might have introduced a side effect, according to the documentation:

> [response handler] Executed after the whole response has been received from the upstream service, but before sending any part of it to the client.

This PR fix the issue by registering a header handler instead of a response handler.

### How to test

1. Run a server with SSE:
```js
const http = require('http');

http.createServer((req, res) => {
  res.writeHead(200, {
    'Content-Type': 'text/event-stream',
    'Cache-Control': 'no-cache',
    'Connection': 'keep-alive'
  });

  setInterval(() => {
    res.write(`data: ${new Date().toLocaleTimeString()}\n\n`);
  }, 1000);
}).listen(3000, () => {
  console.log('Server running at http://localhost:3000/');
});
```

2. Register a Kong route to the server.
3. Make an HTTP Request. Kong should keep sending new events. 

Resolves #88