### PR TITLE
Export trace ids to nginx vars and prefer plugin config to env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ luacov.report.out
 # exclude Pongo containerid file
 .containerid
 .DS_Store
+# exclude LuaCov html report
+luacov.report.html

--- a/examples/nginx_log_injection/README.md
+++ b/examples/nginx_log_injection/README.md
@@ -1,0 +1,42 @@
+# Log Correlation using NGINX variables
+
+This is a `docker compose` setup that showcases how to add `trace_id` and `span_id` to the nginx logs.
+
+## How to run the example
+
+1. Start the services using Docker compose with your Datadog API key:
+
+```shell
+DD_API_KEY=<KEY> docker compose up
+```
+
+2. Send a request to Kong to generate traffic and a trace
+
+```shell
+curl http://localhost:8000/foo
+{
+  "headers": {
+    "Accept": "*/*",
+    "Host": "httpbin.org",
+    "Traceparent": "00-c9a6361300000000269a8b8c076bafcb-55eb48277a5d69e1-01",
+    "Tracestate": "dd=p:55eb48277a5d69e1;s:1;t.tid:c9a6361300000000;t.dm:-0",
+    "User-Agent": "curl/8.6.0",
+    "X-Amzn-Trace-Id": "Root=1-66587c78-12932e884e34a78e68008bc4",
+    "X-Datadog-Parent-Id": "6191121447144745441",
+    "X-Datadog-Sampling-Priority": "1",
+    "X-Datadog-Tags": "_dd.p.tid=c9a6361300000000,_dd.p.dm=-0",
+    "X-Datadog-Trace-Id": "2781689153390882763",
+    "X-Forwarded-Host": "localhost",
+    "X-Forwarded-Path": "/foo",
+    "X-Forwarded-Prefix": "/foo"
+  }
+}
+```
+
+3. View the logs in the kong docker container. You'll see the trace_id (aa075....) and span_id (44ac...) at the end of the logs
+
+```shell
+kong-dbless-1  | 192.168.65.1 - - [14/Aug/2025:19:21:06 +0000] "GET /foo HTTP/1.1" 200 aa075e22000000008d2bf61b89079b85 44aca5af59df8fa0
+```
+
+The trace should be reported in your Datadog account. You may have to augment your Kong proxy log parsing rules to parse out the ids to attributes on the log for it to be properly linked to the trace

--- a/examples/nginx_log_injection/docker-compose.yml
+++ b/examples/nginx_log_injection/docker-compose.yml
@@ -1,0 +1,43 @@
+services:
+  # `agent` is the Datadog Agent to which traces are sent.
+  # `agent` needs an API key set in the environment as the
+  # `DD_API_KEY` environment variable.
+  datadog-agent:
+    image: 'datadog/agent'
+    labels:
+      com.datadoghq.ad.logs: '[{"type": "file", "source": "kong", "service": "nginx-log-injection-example-service", "path": "/shared/log-tracing.log"}]'
+    ports:
+      - 8126:8126
+    volumes:
+      - '/var/run/docker.sock:/var/run/docker.sock:ro'
+      - '/proc/:/host/proc/:ro'
+      - '/sys/fs/cgroup/:/host/sys/fs/cgroup:ro'
+      - shared-volume:/shared:ro
+    environment:
+      - DD_SITE
+      - DD_API_KEY
+      - DD_APM_ENABLED=true
+      - DD_LOGS_ENABLED=true
+      - DD_LOG_LEVEL=ERROR
+
+  kong-dbless:
+    image: 'kong/kong-gateway:3.10'
+    user: root
+    links:
+      - datadog-agent
+    volumes:
+      - ./kong.yaml:/kong/declarative/kong.yaml
+      - ../../kong:/tmp/custom_plugins/kong
+      - ./kong_configs/kong.conf:/etc/kong/kong.conf
+      - ./kong_configs/server_vars.kong.conf:/etc/kong/server_vars.kong.conf
+      - ./kong_configs/log-format.conf:/etc/kong/log-format.conf
+      - ./kong_configs/nginx-custom.conf:/usr/local/kong/nginx-custom.conf
+      - shared-volume:/shared
+    ports:
+      - 8000:8000
+      - 8001:8001
+      - 8002:8002
+    command: kong docker-start -c /etc/kong/kong.conf
+
+volumes:
+  shared-volume:

--- a/examples/nginx_log_injection/kong.yaml
+++ b/examples/nginx_log_injection/kong.yaml
@@ -1,0 +1,15 @@
+_format_version: "3.0"
+_transform: true
+
+services:
+- name: service-a
+  url: http://httpbin.org/headers
+  plugins:
+    - name: ddtrace
+      config:
+        agent_host: datadog-agent
+        service_name: log-correlation-example-service
+  routes:
+  - name: my-route-a
+    paths:
+    - /foo

--- a/examples/nginx_log_injection/kong_configs/kong.conf
+++ b/examples/nginx_log_injection/kong_configs/kong.conf
@@ -1,0 +1,26 @@
+
+prefix = /usr/local/kong/
+log_level = info
+
+database = off
+declarative_config = /kong/declarative/kong.yaml
+
+
+# Use the log format defined in the nginx-custom.conf for the proxy access log
+proxy_access_log = /dev/stdout ddtrace-extended
+proxy_error_log = /dev/stderr
+
+admin_access_log = /dev/stdout ddtrace-extended
+admin_error_log = /dev/stderr
+
+admin_list = 0.0.0.0:8001
+admin_gui_url = http://localhost:8002
+lua_package_path = /tmp/custom_plugins/?.lua
+plugins = bundled,ddtrace
+
+# Adds an include file to the proxy location block of the nginx config so that we can default
+# the `datadog_trace_id` and `datadog_span_id` nginx variables so that they can be used in the log format
+nginx_location_include = /etc/kong/server_vars.kong.conf
+# Add the log format to the http section of the nginx config so that the log format can be used by in
+# the proxy access log
+nginx_http_include = /etc/kong/log-format.conf

--- a/examples/nginx_log_injection/kong_configs/log-format.conf
+++ b/examples/nginx_log_injection/kong_configs/log-format.conf
@@ -1,0 +1,1 @@
+log_format ddtrace-extended '$remote_addr - $remote_user [$time_local] "$request" $status $datadog_trace_id $datadog_span_id';

--- a/examples/nginx_log_injection/kong_configs/server_vars.kong.conf
+++ b/examples/nginx_log_injection/kong_configs/server_vars.kong.conf
@@ -1,0 +1,4 @@
+# This defines default vaules for the following nginx variables.
+# Plugins can modify/read this variables, but not define them
+set $datadog_trace_id '';
+set $datadog_span_id '';

--- a/kong/plugins/ddtrace/handler.lua
+++ b/kong/plugins/ddtrace/handler.lua
@@ -66,6 +66,14 @@ local function expose_tracing_variables(span)
     local kong_shared = kong.ctx.shared
     kong_shared.datadog_sdk_trace_id = trace_id
     kong_shared.datadog_sdk_span_id = span_id
+
+    -- Set nginx variables
+    if ngx.var.datadog_trace_id ~= nil then
+        ngx.var.datadog_trace_id = trace_id
+    end
+    if ngx.var.datadog_span_id ~= nil then
+        ngx.var.datadog_span_id = trace_id
+    end
 end
 
 -- apply resource_name_rules to the provided URI
@@ -178,7 +186,7 @@ local function make_root_span(conf, start_timestamp)
     local path = req.get_path()
 
     local span_options = {
-        service = ddtrace_conf.service,
+        service = conf.service_name or ddtrace_conf.service,
         name = "kong.request",
         start_us = start_timestamp,
         -- TODO: decrease cardinality of path value


### PR DESCRIPTION
There are 2 fixes here:

1. Export `datadog_trace_id` and `datadog_span_id` as nginx variables so that they can be used in nginx access logs
2. Prefer plugin configuration values to environment variables in the kong hosting environment