### PR TITLE
fix: report status code on proxy span

### DIFF
--- a/kong/plugins/ddtrace/handler.lua
+++ b/kong/plugins/ddtrace/handler.lua
@@ -336,6 +336,13 @@ local function header_filter(_)
         span:set_tag("kong.route", "none")
     end
 
+    local status_code = kong.response.get_status()
+    span:set_tag("http.status_code", status_code)
+    if status_code >= 500 then
+        span:set_tag("error", true)
+        span.error = status_code
+    end
+
     span:finish(now)
 end
 
@@ -350,13 +357,6 @@ local function log(conf)
 
     local request_span = ctx.request_span
     local agent_writer = get_agent_writer(conf, ddtrace_conf.agent_url)
-
-    local status_code = kong.response.get_status()
-    request_span:set_tag("http.status_code", status_code)
-    if status_code >= 500 then
-        request_span:set_tag("error", true)
-        request_span.error = status_code
-    end
 
     if header_tags then
         request_span:set_http_header_tags(header_tags, kong.request.get_header, kong.response.get_header)


### PR DESCRIPTION
# Description

Move the status code reporting to the proxy span to more accurately reflect where the error occurs. This also ensures that the inferred service is correctly marked with an error.

<img width="834" height="477" alt="Screenshot 2025-09-04 at 15 34 12" src="https://github.com/user-attachments/assets/1df9c3d4-f196-4dec-a7a3-fe4495cc50d3" />

<img width="1514" height="415" alt="Screenshot 2025-09-04 at 15 34 05" src="https://github.com/user-attachments/assets/bf2b89ff-4504-4c0e-9510-0d3b23b8015b" />
