### PR TITLE
Add Datadog code coverage upload

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -37,3 +37,46 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: DataDog/kong-plugin-ddtrace
+      - name: Convert luacov to LCOV
+        if: always()
+        run: |
+          python3 -c "
+          import re, sys
+          lcov = []
+          with open('luacov.report.out') as f:
+              lines = f.readlines()
+          fname = None; lf = lh = 0; sep_count = 0
+          for line in lines:
+              line = line.rstrip('\n')
+              if re.match(r'^={10,}$', line):
+                  sep_count += 1
+                  if sep_count == 2:
+                      sep_count = 0
+                  elif sep_count == 1:
+                      if fname:
+                          lcov.append(f'LF:{lf}'); lcov.append(f'LH:{lh}'); lcov.append('end_of_record')
+                      fname = None; lf = lh = 0
+                  continue
+              if sep_count == 1:
+                  fname = line.strip(); lcov.append(f'SF:{fname}'); sep_count = 0; continue
+              if not fname: continue
+              m = re.match(r'^(\*{5}0|\s*\d+)\s+(\d+)\t', line)
+              if not m: continue
+              cf = m.group(1).strip(); ln = int(m.group(2))
+              if '*' in cf:
+                  lcov.append(f'DA:{ln},0'); lf += 1
+              elif cf and int(cf) > 0:
+                  lcov.append(f'DA:{ln},{cf}'); lf += 1; lh += 1
+          if fname:
+              lcov.append(f'LF:{lf}'); lcov.append(f'LH:{lh}'); lcov.append('end_of_record')
+          with open('coverage.lcov','w') as f: f.write('\n'.join(lcov)+'\n')
+          print(f'Converted {sum(1 for l in lcov if l.startswith(\"SF:\"))} files to LCOV')
+          "
+      - name: Upload coverage to Datadog
+        if: always()
+        continue-on-error: true
+        uses: DataDog/coverage-upload-github-action@v1
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          files: coverage.lcov
+          format: lcov

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Upload coverage to Datadog
         if: always()
         continue-on-error: true
-        uses: DataDog/coverage-upload-github-action@v1
+        uses: DataDog/coverage-upload-github-action@d2cf302a39c05e0ad22063360a2bf6ce0cc4906c # v1
         with:
           api_key: ${{ secrets.DD_API_KEY }}
           files: coverage.lcov

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Upload coverage to Datadog
         if: always()
         continue-on-error: true
-        uses: DataDog/coverage-upload-github-action@v1
+        uses: DataDog/coverage-upload-github-action@d2cf302a39c05e0ad22063360a2bf6ce0cc4906c # v1
         with:
           api_key: ${{ secrets.DD_API_KEY }}
           files: coverage.lcov

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,49 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: DataDog/kong-plugin-ddtrace
+      - name: Convert luacov to LCOV
+        if: always()
+        run: |
+          python3 -c "
+          import re, sys
+          lcov = []
+          with open('luacov.report.out') as f:
+              lines = f.readlines()
+          fname = None; lf = lh = 0; sep_count = 0
+          for line in lines:
+              line = line.rstrip('\n')
+              if re.match(r'^={10,}$', line):
+                  sep_count += 1
+                  if sep_count == 2:
+                      sep_count = 0
+                  elif sep_count == 1:
+                      if fname:
+                          lcov.append(f'LF:{lf}'); lcov.append(f'LH:{lh}'); lcov.append('end_of_record')
+                      fname = None; lf = lh = 0
+                  continue
+              if sep_count == 1:
+                  fname = line.strip(); lcov.append(f'SF:{fname}'); sep_count = 0; continue
+              if not fname: continue
+              m = re.match(r'^(\*{5}0|\s*\d+)\s+(\d+)\t', line)
+              if not m: continue
+              cf = m.group(1).strip(); ln = int(m.group(2))
+              if '*' in cf:
+                  lcov.append(f'DA:{ln},0'); lf += 1
+              elif cf and int(cf) > 0:
+                  lcov.append(f'DA:{ln},{cf}'); lf += 1; lh += 1
+          if fname:
+              lcov.append(f'LF:{lf}'); lcov.append(f'LH:{lh}'); lcov.append('end_of_record')
+          with open('coverage.lcov','w') as f: f.write('\n'.join(lcov)+'\n')
+          print(f'Converted {sum(1 for l in lcov if l.startswith(\"SF:\"))} files to LCOV')
+          "
+      - name: Upload coverage to Datadog
+        if: always()
+        continue-on-error: true
+        uses: DataDog/coverage-upload-github-action@v1
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          files: coverage.lcov
+          format: lcov
 
   package:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## What does this PR do?

We're migrating Datadog repositories from Codecov to [Datadog Code Coverage](https://docs.datadoghq.com/code_analysis/code_coverage/) for tracking test coverage. This PR is the first step: it adds a Datadog coverage upload **alongside** the existing Codecov upload so we can run both systems in parallel and verify parity before switching over.

## Changes

- Added a luacov-to-LCOV conversion step after tests run (parses `luacov.report.out` into `coverage.lcov`)
- Added `DataDog/coverage-upload-github-action@v1` upload step to both `dev.yml` (PR) and `main.yml` (push to main) workflows
- The existing Codecov uploads are **unchanged** — nothing is removed or modified
- The upload uses `continue-on-error: true` so it cannot block CI
- The conversion handles luacov's report format, distinguishing executable vs non-executable lines

## Why are we doing this?

As part of a company-wide effort, we're consolidating code coverage reporting into Datadog's own Code Coverage product. This gives us:
- Coverage data integrated directly into Datadog CI Visibility
- PR gates and coverage checks natively in Datadog
- No dependency on a third-party service (Codecov) for coverage reporting

## Validation

Pending — `dev.yml` excludes PRs to main, so CI tests won't run on this PR. Coverage comparison will be possible after merge when the push-triggered workflow runs.

## Next steps (not in this PR)

Once this PR is merged and we've confirmed Datadog coverage is stable over several commits:
1. Remove the Codecov upload steps and `CODECOV_TOKEN` secret
2. Optionally configure PR gates in `code-coverage.datadog.yml`

## No action needed from reviewers beyond normal review

This is a low-risk, additive change. The new upload steps run independently of the existing CI pipeline and cannot cause test failures.