### PR TITLE
Add Datadog code coverage upload

### DIFF
--- a/.github/scripts/luacov_to_lcov.py
+++ b/.github/scripts/luacov_to_lcov.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Convert luacov.report.out to LCOV format for Datadog Code Coverage upload.
+
+Background:
+  - pongo runs tests inside a Docker container mounted at /kong-plugin/
+  - luacov generates luacov.report.out with container-absolute paths (SF:/kong-plugin/...)
+  - Datadog's coverage upload requires LCOV format; we pass base-path=/kong-plugin
+    so the tool strips the container prefix and resolves paths relative to the repo root
+
+luacov.report.out format (per section):
+  ======...======   (separator, 30+ = signs)
+  /path/to/file.lua
+  ======...======
+     N source line  (hit count N, or ***0 for unexecuted)
+     ...
+"""
+import re
+import sys
+
+INPUT = "luacov.report.out"
+OUTPUT = "coverage.lcov"
+
+try:
+    with open(INPUT) as f:
+        content = f.read()
+except FileNotFoundError:
+    print(f"Error: {INPUT} not found", file=sys.stderr)
+    sys.exit(1)
+
+sections = re.split(r"(?m)^={30,}\n", content)
+lcov = []
+i = 1
+while i < len(sections):
+    fname = sections[i].strip()
+    if not fname:
+        i += 1
+        continue
+    i += 1
+    data = sections[i] if i < len(sections) else ""
+    lcov.append(f"SF:{fname}")
+    lf = lh = 0
+    line_no = 1
+    for line in data.splitlines():
+        m = re.match(r"^(\*{3}0|\s*(\d+))\s", line)
+        if m:
+            hits_str = m.group(1).strip()
+            hits = 0 if hits_str.startswith("*") else int(hits_str)
+            lcov.append(f"DA:{line_no},{hits}")
+            lf += 1
+            if hits > 0:
+                lh += 1
+        line_no += 1
+    lcov.extend([f"LF:{lf}", f"LH:{lh}", "end_of_record"])
+    i += 1
+
+with open(OUTPUT, "w") as f:
+    f.write("\n".join(lcov) + "\n")
+
+n_files = sum(1 for l in lcov if l.startswith("SF:"))
+print(f"Converted {n_files} files to LCOV → {OUTPUT}")

--- a/.github/scripts/luacov_to_lcov.py
+++ b/.github/scripts/luacov_to_lcov.py
@@ -2,10 +2,12 @@
 """Convert luacov.report.out to LCOV format for Datadog Code Coverage upload.
 
 Background:
-  - pongo runs tests inside a Docker container mounted at /kong-plugin/
-  - luacov generates luacov.report.out with container-absolute paths (SF:/kong-plugin/...)
-  - Datadog's coverage upload requires LCOV format; we pass base-path=/kong-plugin
-    so the tool strips the container prefix and resolves paths relative to the repo root
+  - Datadog Code Coverage does not natively support luacov's report format. Supported
+    formats are: LCOV, Cobertura XML, JaCoCo XML, Clover, OpenCover, SimpleCov, Go Coverprofile.
+  - pongo runs tests inside a Docker container mounted at /kong-plugin/, so luacov
+    generates luacov.report.out with container-absolute paths (SF:/kong-plugin/...).
+  - We convert to LCOV and pass base-path=/kong-plugin to the upload tool, which strips
+    the container prefix and resolves paths relative to the repo root.
 
 luacov.report.out format (per section):
   ======...======   (separator, 30+ = signs)

--- a/.github/scripts/luacov_to_lcov.py
+++ b/.github/scripts/luacov_to_lcov.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python3
 """Convert luacov.report.out to LCOV format for Datadog Code Coverage upload.
 
-Background:
-  - Datadog Code Coverage does not natively support luacov's report format. Supported
-    formats are: LCOV, Cobertura XML, JaCoCo XML, Clover, OpenCover, SimpleCov, Go Coverprofile.
-  - pongo runs tests inside a Docker container mounted at /kong-plugin/, so luacov
-    generates luacov.report.out with container-absolute paths (SF:/kong-plugin/...).
-  - We convert to LCOV and pass base-path=/kong-plugin to the upload tool, which strips
-    the container prefix and resolves paths relative to the repo root.
+Datadog Code Coverage does not natively support luacov's report format. Supported
+formats are: LCOV, Cobertura XML, JaCoCo XML, Clover, OpenCover, SimpleCov, Go Coverprofile.
+This script converts luacov's output to LCOV so it can be uploaded to Datadog.
 
 luacov.report.out format (per section):
   ======...======   (separator, 30+ = signs)

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -71,10 +71,6 @@ jobs:
           with open('coverage.lcov','w') as f: f.write('\n'.join(lcov)+'\n')
           print(f'Converted {sum(1 for l in lcov if l.startswith(\"SF:\"))} files to LCOV')
           "
-      - name: Debug luacov.report.out
-        run: head -30 luacov.report.out || echo "File not found"
-      - name: Debug coverage.lcov
-        run: head -20 coverage.lcov || echo "File not found"
       - name: Get Datadog credentials
         id: dd-sts
         continue-on-error: true

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -75,6 +75,8 @@ jobs:
           with open('coverage.lcov','w') as f: f.write('\n'.join(lcov)+'\n')
           print(f'Converted {sum(1 for l in lcov if l.startswith(\"SF:\"))} files to LCOV')
           "
+      - name: Debug coverage.lcov
+        run: head -20 coverage.lcov || echo "File not found"
       - name: Get Datadog credentials
         id: dd-sts
         continue-on-error: true

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -44,7 +44,7 @@ jobs:
         if: always()
         run: |
           python3 -c "
-          import re, sys
+          import re
           lcov = []
           with open('luacov.report.out') as f:
               lines = f.readlines()
@@ -54,14 +54,18 @@ jobs:
               if re.match(r'^={10,}$', line):
                   sep_count += 1
                   if sep_count == 2:
-                      sep_count = 0
+                      sep_count = 0  # Now in coverage-data section
                   elif sep_count == 1:
                       if fname:
                           lcov.append(f'LF:{lf}'); lcov.append(f'LH:{lh}'); lcov.append('end_of_record')
                       fname = None; lf = lh = 0
                   continue
-              if sep_count == 1:
-                  fname = line.strip(); lcov.append(f'SF:{fname}'); sep_count = 0; continue
+              if sep_count == 1 and not fname:
+                  candidate = line.strip()
+                  if candidate and candidate.lower() != 'summary':
+                      fname = candidate; lcov.append(f'SF:{fname}')
+                  # Do NOT reset sep_count here; let next === become sep_count=2
+                  continue
               if not fname: continue
               m = re.match(r'^(\*{5}0|\s*\d+)\s+(\d+)\t', line)
               if not m: continue

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -21,6 +21,9 @@ jobs:
 
   run-test:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write # needed for dd-sts OIDC token exchange
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - uses: Kong/kong-pongo-action@5972effad7a566aed12b879b559bbff07d258d51 #v1.0.3

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -79,6 +79,8 @@ jobs:
           with open('coverage.lcov','w') as f: f.write('\n'.join(lcov)+'\n')
           print(f'Converted {sum(1 for l in lcov if l.startswith(\"SF:\"))} files to LCOV')
           "
+      - name: Debug luacov.report.out
+        run: head -30 luacov.report.out || echo "File not found"
       - name: Debug coverage.lcov
         run: head -20 coverage.lcov || echo "File not found"
       - name: Get Datadog credentials

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -45,37 +45,29 @@ jobs:
         run: |
           python3 -c "
           import re
-          lcov = []
           with open('luacov.report.out') as f:
-              lines = f.readlines()
-          fname = None; lf = lh = 0; sep_count = 0
-          for line in lines:
-              line = line.rstrip('\n')
-              if re.match(r'^={10,}$', line):
-                  sep_count += 1
-                  if sep_count == 2:
-                      sep_count = 0  # Now in coverage-data section
-                  elif sep_count == 1:
-                      if fname:
-                          lcov.append(f'LF:{lf}'); lcov.append(f'LH:{lh}'); lcov.append('end_of_record')
-                      fname = None; lf = lh = 0
-                  continue
-              if sep_count == 1 and not fname:
-                  candidate = line.strip()
-                  if candidate and candidate.lower() != 'summary':
-                      fname = candidate; lcov.append(f'SF:{fname}')
-                  # Do NOT reset sep_count here; let next === become sep_count=2
-                  continue
-              if not fname: continue
-              m = re.match(r'^(\*{5}0|\s*\d+)\s+(\d+)\t', line)
-              if not m: continue
-              cf = m.group(1).strip(); ln = int(m.group(2))
-              if '*' in cf:
-                  lcov.append(f'DA:{ln},0'); lf += 1
-              elif cf and int(cf) > 0:
-                  lcov.append(f'DA:{ln},{cf}'); lf += 1; lh += 1
-          if fname:
-              lcov.append(f'LF:{lf}'); lcov.append(f'LH:{lh}'); lcov.append('end_of_record')
+              content = f.read()
+          sections = re.split(r'(?m)^={30,}\n', content)
+          lcov = []
+          i = 1
+          while i < len(sections):
+              fname = sections[i].strip()
+              if not fname:
+                  i += 1; continue
+              i += 1
+              data = sections[i] if i < len(sections) else ''
+              lcov.append(f'SF:{fname}')
+              lf = lh = 0; line_no = 1
+              for line in data.splitlines():
+                  m = re.match(r'^(\*{3}0|\s*(\d+))\s', line)
+                  if m:
+                      hits_str = m.group(1).strip()
+                      hits = 0 if hits_str.startswith('*') else int(hits_str)
+                      lcov.append(f'DA:{line_no},{hits}'); lf += 1
+                      if hits > 0: lh += 1
+                  line_no += 1
+              lcov.extend([f'LF:{lf}', f'LH:{lh}', 'end_of_record'])
+              i += 1
           with open('coverage.lcov','w') as f: f.write('\n'.join(lcov)+'\n')
           print(f'Converted {sum(1 for l in lcov if l.startswith(\"SF:\"))} files to LCOV')
           "

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -42,35 +42,7 @@ jobs:
           slug: DataDog/kong-plugin-ddtrace
       - name: Convert luacov to LCOV
         if: always()
-        run: |
-          python3 -c "
-          import re
-          with open('luacov.report.out') as f:
-              content = f.read()
-          sections = re.split(r'(?m)^={30,}\n', content)
-          lcov = []
-          i = 1
-          while i < len(sections):
-              fname = sections[i].strip()
-              if not fname:
-                  i += 1; continue
-              i += 1
-              data = sections[i] if i < len(sections) else ''
-              lcov.append(f'SF:{fname}')
-              lf = lh = 0; line_no = 1
-              for line in data.splitlines():
-                  m = re.match(r'^(\*{3}0|\s*(\d+))\s', line)
-                  if m:
-                      hits_str = m.group(1).strip()
-                      hits = 0 if hits_str.startswith('*') else int(hits_str)
-                      lcov.append(f'DA:{line_no},{hits}'); lf += 1
-                      if hits > 0: lh += 1
-                  line_no += 1
-              lcov.extend([f'LF:{lf}', f'LH:{lh}', 'end_of_record'])
-              i += 1
-          with open('coverage.lcov','w') as f: f.write('\n'.join(lcov)+'\n')
-          print(f'Converted {sum(1 for l in lcov if l.startswith(\"SF:\"))} files to LCOV')
-          "
+        run: python3 .github/scripts/luacov_to_lcov.py
       - name: Get Datadog credentials
         id: dd-sts
         continue-on-error: true

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -87,5 +87,5 @@ jobs:
         uses: DataDog/coverage-upload-github-action@d2cf302a39c05e0ad22063360a2bf6ce0cc4906c # v1
         with:
           api_key: ${{ steps.dd-sts.outputs.api_key }}
-          files: coverage.lcov
+          files: ${{ github.workspace }}/coverage.lcov
           format: lcov

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -37,3 +37,46 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: DataDog/kong-plugin-ddtrace
+      - name: Convert luacov to LCOV
+        if: always()
+        run: |
+          python3 -c "
+          import re, sys
+          lcov = []
+          with open('luacov.report.out') as f:
+              lines = f.readlines()
+          fname = None; lf = lh = 0; sep_count = 0
+          for line in lines:
+              line = line.rstrip('\n')
+              if re.match(r'^={10,}$', line):
+                  sep_count += 1
+                  if sep_count == 2:
+                      sep_count = 0
+                  elif sep_count == 1:
+                      if fname:
+                          lcov.append(f'LF:{lf}'); lcov.append(f'LH:{lh}'); lcov.append('end_of_record')
+                      fname = None; lf = lh = 0
+                  continue
+              if sep_count == 1:
+                  fname = line.strip(); lcov.append(f'SF:{fname}'); sep_count = 0; continue
+              if not fname: continue
+              m = re.match(r'^(\*{5}0|\s*\d+)\s+(\d+)\t', line)
+              if not m: continue
+              cf = m.group(1).strip(); ln = int(m.group(2))
+              if '*' in cf:
+                  lcov.append(f'DA:{ln},0'); lf += 1
+              elif cf and int(cf) > 0:
+                  lcov.append(f'DA:{ln},{cf}'); lf += 1; lh += 1
+          if fname:
+              lcov.append(f'LF:{lf}'); lcov.append(f'LH:{lh}'); lcov.append('end_of_record')
+          with open('coverage.lcov','w') as f: f.write('\n'.join(lcov)+'\n')
+          print(f'Converted {sum(1 for l in lcov if l.startswith(\"SF:\"))} files to LCOV')
+          "
+      - name: Upload coverage to Datadog
+        if: always()
+        continue-on-error: true
+        uses: DataDog/coverage-upload-github-action@v1
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          files: coverage.lcov
+          format: lcov

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -72,11 +72,17 @@ jobs:
           with open('coverage.lcov','w') as f: f.write('\n'.join(lcov)+'\n')
           print(f'Converted {sum(1 for l in lcov if l.startswith(\"SF:\"))} files to LCOV')
           "
+      - name: Get Datadog credentials
+        id: dd-sts
+        continue-on-error: true
+        uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
+        with:
+          policy: kong-plugin-ddtrace
       - name: Upload coverage to Datadog
-        if: always()
+        if: steps.dd-sts.outputs.api_key != ''
         continue-on-error: true
         uses: DataDog/coverage-upload-github-action@d2cf302a39c05e0ad22063360a2bf6ce0cc4906c # v1
         with:
-          api_key: ${{ secrets.DD_API_KEY }}
+          api_key: ${{ steps.dd-sts.outputs.api_key }}
           files: coverage.lcov
           format: lcov

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -89,3 +89,4 @@ jobs:
           api_key: ${{ steps.dd-sts.outputs.api_key }}
           files: ${{ github.workspace }}/coverage.lcov
           format: lcov
+          base_path: /kong-plugin

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -89,4 +89,4 @@ jobs:
           api_key: ${{ steps.dd-sts.outputs.api_key }}
           files: ${{ github.workspace }}/coverage.lcov
           format: lcov
-          base_path: /kong-plugin
+          base-path: /kong-plugin

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Upload coverage to Datadog
         if: always()
         continue-on-error: true
-        uses: DataDog/coverage-upload-github-action@v1
+        uses: DataDog/coverage-upload-github-action@d2cf302a39c05e0ad22063360a2bf6ce0cc4906c # v1
         with:
           api_key: ${{ secrets.DD_API_KEY }}
           files: coverage.lcov

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Upload coverage to Datadog
         if: always()
         continue-on-error: true
-        uses: DataDog/coverage-upload-github-action@v1
+        uses: DataDog/coverage-upload-github-action@d2cf302a39c05e0ad22063360a2bf6ce0cc4906c # v1
         with:
           api_key: ${{ secrets.DD_API_KEY }}
           files: coverage.lcov

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,9 @@ jobs:
 
   run-test:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write # needed for dd-sts OIDC token exchange
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - uses: Kong/kong-pongo-action@5972effad7a566aed12b879b559bbff07d258d51 #v1.0.3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,35 +39,7 @@ jobs:
           slug: DataDog/kong-plugin-ddtrace
       - name: Convert luacov to LCOV
         if: always()
-        run: |
-          python3 -c "
-          import re
-          with open('luacov.report.out') as f:
-              content = f.read()
-          sections = re.split(r'(?m)^={30,}\n', content)
-          lcov = []
-          i = 1
-          while i < len(sections):
-              fname = sections[i].strip()
-              if not fname:
-                  i += 1; continue
-              i += 1
-              data = sections[i] if i < len(sections) else ''
-              lcov.append(f'SF:{fname}')
-              lf = lh = 0; line_no = 1
-              for line in data.splitlines():
-                  m = re.match(r'^(\*{3}0|\s*(\d+))\s', line)
-                  if m:
-                      hits_str = m.group(1).strip()
-                      hits = 0 if hits_str.startswith('*') else int(hits_str)
-                      lcov.append(f'DA:{line_no},{hits}'); lf += 1
-                      if hits > 0: lh += 1
-                  line_no += 1
-              lcov.extend([f'LF:{lf}', f'LH:{lh}', 'end_of_record'])
-              i += 1
-          with open('coverage.lcov','w') as f: f.write('\n'.join(lcov)+'\n')
-          print(f'Converted {sum(1 for l in lcov if l.startswith(\"SF:\"))} files to LCOV')
-          "
+        run: python3 .github/scripts/luacov_to_lcov.py
       - name: Get Datadog credentials
         id: dd-sts
         continue-on-error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,34 +41,30 @@ jobs:
         if: always()
         run: |
           python3 -c "
-          import re, sys
-          lcov = []
+          import re
           with open('luacov.report.out') as f:
-              lines = f.readlines()
-          fname = None; lf = lh = 0; sep_count = 0
-          for line in lines:
-              line = line.rstrip('\n')
-              if re.match(r'^={10,}$', line):
-                  sep_count += 1
-                  if sep_count == 2:
-                      sep_count = 0
-                  elif sep_count == 1:
-                      if fname:
-                          lcov.append(f'LF:{lf}'); lcov.append(f'LH:{lh}'); lcov.append('end_of_record')
-                      fname = None; lf = lh = 0
-                  continue
-              if sep_count == 1:
-                  fname = line.strip(); lcov.append(f'SF:{fname}'); sep_count = 0; continue
-              if not fname: continue
-              m = re.match(r'^(\*{5}0|\s*\d+)\s+(\d+)\t', line)
-              if not m: continue
-              cf = m.group(1).strip(); ln = int(m.group(2))
-              if '*' in cf:
-                  lcov.append(f'DA:{ln},0'); lf += 1
-              elif cf and int(cf) > 0:
-                  lcov.append(f'DA:{ln},{cf}'); lf += 1; lh += 1
-          if fname:
-              lcov.append(f'LF:{lf}'); lcov.append(f'LH:{lh}'); lcov.append('end_of_record')
+              content = f.read()
+          sections = re.split(r'(?m)^={30,}\n', content)
+          lcov = []
+          i = 1
+          while i < len(sections):
+              fname = sections[i].strip()
+              if not fname:
+                  i += 1; continue
+              i += 1
+              data = sections[i] if i < len(sections) else ''
+              lcov.append(f'SF:{fname}')
+              lf = lh = 0; line_no = 1
+              for line in data.splitlines():
+                  m = re.match(r'^(\*{3}0|\s*(\d+))\s', line)
+                  if m:
+                      hits_str = m.group(1).strip()
+                      hits = 0 if hits_str.startswith('*') else int(hits_str)
+                      lcov.append(f'DA:{line_no},{hits}'); lf += 1
+                      if hits > 0: lh += 1
+                  line_no += 1
+              lcov.extend([f'LF:{lf}', f'LH:{lh}', 'end_of_record'])
+              i += 1
           with open('coverage.lcov','w') as f: f.write('\n'.join(lcov)+'\n')
           print(f'Converted {sum(1 for l in lcov if l.startswith(\"SF:\"))} files to LCOV')
           "

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,6 +86,7 @@ jobs:
           api_key: ${{ steps.dd-sts.outputs.api_key }}
           files: ${{ github.workspace }}/coverage.lcov
           format: lcov
+          base_path: /kong-plugin
 
   package:
     runs-on: ubuntu-22.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
           api_key: ${{ steps.dd-sts.outputs.api_key }}
           files: ${{ github.workspace }}/coverage.lcov
           format: lcov
-          base_path: /kong-plugin
+          base-path: /kong-plugin
 
   package:
     runs-on: ubuntu-22.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,49 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: DataDog/kong-plugin-ddtrace
+      - name: Convert luacov to LCOV
+        if: always()
+        run: |
+          python3 -c "
+          import re, sys
+          lcov = []
+          with open('luacov.report.out') as f:
+              lines = f.readlines()
+          fname = None; lf = lh = 0; sep_count = 0
+          for line in lines:
+              line = line.rstrip('\n')
+              if re.match(r'^={10,}$', line):
+                  sep_count += 1
+                  if sep_count == 2:
+                      sep_count = 0
+                  elif sep_count == 1:
+                      if fname:
+                          lcov.append(f'LF:{lf}'); lcov.append(f'LH:{lh}'); lcov.append('end_of_record')
+                      fname = None; lf = lh = 0
+                  continue
+              if sep_count == 1:
+                  fname = line.strip(); lcov.append(f'SF:{fname}'); sep_count = 0; continue
+              if not fname: continue
+              m = re.match(r'^(\*{5}0|\s*\d+)\s+(\d+)\t', line)
+              if not m: continue
+              cf = m.group(1).strip(); ln = int(m.group(2))
+              if '*' in cf:
+                  lcov.append(f'DA:{ln},0'); lf += 1
+              elif cf and int(cf) > 0:
+                  lcov.append(f'DA:{ln},{cf}'); lf += 1; lh += 1
+          if fname:
+              lcov.append(f'LF:{lf}'); lcov.append(f'LH:{lh}'); lcov.append('end_of_record')
+          with open('coverage.lcov','w') as f: f.write('\n'.join(lcov)+'\n')
+          print(f'Converted {sum(1 for l in lcov if l.startswith(\"SF:\"))} files to LCOV')
+          "
+      - name: Upload coverage to Datadog
+        if: always()
+        continue-on-error: true
+        uses: DataDog/coverage-upload-github-action@v1
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          files: coverage.lcov
+          format: lcov
 
   package:
     runs-on: ubuntu-22.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,7 +84,7 @@ jobs:
         uses: DataDog/coverage-upload-github-action@d2cf302a39c05e0ad22063360a2bf6ce0cc4906c # v1
         with:
           api_key: ${{ steps.dd-sts.outputs.api_key }}
-          files: coverage.lcov
+          files: ${{ github.workspace }}/coverage.lcov
           format: lcov
 
   package:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,12 +69,18 @@ jobs:
           with open('coverage.lcov','w') as f: f.write('\n'.join(lcov)+'\n')
           print(f'Converted {sum(1 for l in lcov if l.startswith(\"SF:\"))} files to LCOV')
           "
+      - name: Get Datadog credentials
+        id: dd-sts
+        continue-on-error: true
+        uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
+        with:
+          policy: kong-plugin-ddtrace
       - name: Upload coverage to Datadog
-        if: always()
+        if: steps.dd-sts.outputs.api_key != ''
         continue-on-error: true
         uses: DataDog/coverage-upload-github-action@d2cf302a39c05e0ad22063360a2bf6ce0cc4906c # v1
         with:
-          api_key: ${{ secrets.DD_API_KEY }}
+          api_key: ${{ steps.dd-sts.outputs.api_key }}
           files: coverage.lcov
           format: lcov
 


### PR DESCRIPTION
## What does this PR do?

We're migrating Datadog repositories from Codecov to [Datadog Code Coverage](https://docs.datadoghq.com/code_analysis/code_coverage/) for tracking test coverage. This PR is the first step: it adds a Datadog coverage upload **alongside** the existing Codecov upload so we can run both systems in parallel and verify parity before switching over.

This replaces fork PR #97 (now pushed from origin branch).

## Changes

- Added a luacov-to-LCOV conversion step after tests run (parses `luacov.report.out` into `coverage.lcov`)
- Added `DataDog/coverage-upload-github-action` upload step to both `dev.yml` (PR) and `main.yml` (push to main) workflows
- The existing Codecov uploads are **unchanged** — nothing is removed or modified
- The upload uses `continue-on-error: true` so it cannot block CI
- The conversion handles luacov's report format, distinguishing executable vs non-executable lines

## Why are we doing this?

As part of a company-wide effort, we're consolidating code coverage reporting into Datadog's own Code Coverage product. This gives us:
- Coverage data integrated directly into Datadog CI Visibility
- PR gates and coverage checks natively in Datadog
- No dependency on a third-party service (Codecov) for coverage reporting

## Validation

Note: `dev.yml` excludes PRs to main (`branches: '!main'`), so the test job won't auto-trigger on this PR. Coverage comparison will be possible after merge when the push-triggered `main.yml` workflow runs, or via `workflow_dispatch`.

## Next steps (not in this PR)

Once this PR is merged and we've confirmed Datadog coverage is stable over several commits:
1. Remove the Codecov upload steps and `CODECOV_TOKEN` secret
2. Optionally configure PR gates in `code-coverage.datadog.yml`

## No action needed from reviewers beyond normal review

This is a low-risk, additive change. The new upload steps run independently of the existing CI pipeline and cannot cause test failures.