### PR TITLE
ci: add system-tests workflow

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -38,7 +38,7 @@ jobs:
       scenarios: DEFAULT
       scenarios_groups: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && 'tracer_release' || '' }}
       skip_empty_scenarios: true
-      push_to_test_optimization: ${{ github.actor != 'dependabot[bot]' }}
+      push_to_test_optimization: ${{ github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
 
   check:
     name: Check system tests success

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -17,12 +17,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
-        with:
-          path: kong-plugin-ddtrace
+      - run: mkdir -p artifact/kong-plugin-ddtrace && cp -r kong spec *.rockspec LICENSE README.md artifact/kong-plugin-ddtrace/
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
           name: binaries
-          path: kong-plugin-ddtrace
+          path: artifact
 
   system-tests:
     needs: build

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -9,6 +9,9 @@ on:
     - cron: '00 04 * * *'
 
 concurrency:
+  # this ensures that only one workflow runs at a time for a given branch on pull requests
+  # as the group key is the workflow name and the branch name
+  # for scheduled runs and pushes to main, we use the run id to ensure that all runs are executed
   group: ${{ (github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.ref)) || format('{0}-{1}', github.workflow, github.run_id) }}
   cancel-in-progress: true
 
@@ -16,7 +19,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4.3.1
       - run: mkdir -p artifact/kong-plugin-ddtrace && cp -r kong spec *.rockspec LICENSE README.md artifact/kong-plugin-ddtrace/
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
@@ -36,6 +39,7 @@ jobs:
       library: cpp_kong
       binaries_artifact: binaries
       scenarios: DEFAULT
+      # On push/schedule, also run the broader tracer_release group; on PRs only DEFAULT
       scenarios_groups: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && 'tracer_release' || '' }}
       skip_empty_scenarios: true
       push_to_test_optimization: ${{ github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -1,0 +1,49 @@
+name: System Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: '00 04 * * *'
+
+concurrency:
+  group: ${{ (github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.ref)) || format('{0}-{1}', github.workflow, github.run_id) }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: kong-plugin-ddtrace
+      - uses: actions/upload-artifact@v4
+        with:
+          name: binaries
+          path: kong-plugin-ddtrace
+
+  system-tests:
+    needs: build
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@main
+    secrets:
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      TEST_OPTIMIZATION_API_KEY: ${{ secrets.DD_API_KEY }}
+    permissions:
+      contents: read
+      packages: write
+    with:
+      library: cpp_kong
+      binaries_artifact: binaries
+      desired_execution_time: 300
+      scenarios_groups: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && 'tracer_release' || 'end_to_end' }}
+      skip_empty_scenarios: true
+      push_to_test_optimization: ${{ github.actor != 'dependabot[bot]' }}
+
+  check:
+    name: Check system tests success
+    runs-on: ubuntu-latest
+    needs: system-tests
+    steps:
+      - run: exit 0

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -36,8 +36,8 @@ jobs:
     with:
       library: cpp_kong
       binaries_artifact: binaries
-      desired_execution_time: 300
-      scenarios_groups: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && 'tracer_release' || 'end_to_end' }}
+      scenarios: DEFAULT
+      scenarios_groups: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && 'tracer_release' || '' }}
       skip_empty_scenarios: true
       push_to_test_optimization: ${{ github.actor != 'dependabot[bot]' }}
 

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -16,10 +16,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           path: kong-plugin-ddtrace
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
           name: binaries
           path: kong-plugin-ddtrace

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
@@ -43,7 +43,12 @@ jobs:
 
   check:
     name: Check system tests success
-    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    runs-on: ubuntu-22.04
     needs: system-tests
     steps:
-      - run: exit 0
+      - run: |
+          if [[ "${{ needs.system-tests.result }}" != "success" ]]; then
+            echo "System tests failed with result: ${{ needs.system-tests.result }}"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that runs [DataDog/system-tests](https://github.com/DataDog/system-tests) against the Kong plugin
- Triggers on push to main, pull requests, and nightly (4am UTC)
- Follows the same pattern used by [nginx-datadog](https://github.com/DataDog/nginx-datadog/blob/master/.github/workflows/system-tests.yml) and [httpd-datadog](https://github.com/DataDog/httpd-datadog/blob/main/.github/workflows/system-tests.yml)

## How it works
1. **build** job: checks out the plugin source into a `kong-plugin-ddtrace/` directory and uploads it as an artifact
2. **system-tests** job: calls the system-tests reusable workflow with `library: cpp_kong` and the artifact `system-tests` downloads it to `binaries/kong-plugin-ddtrace/` which `install_ddtrace.sh` detects as a local override
3. **check** job: gates required status checks on system-tests success

## Scenarios
- **Pull requests**: `DEFAULT` scenario only (basic tracing tests, fast feedback)
- **Push to main / nightly**: `DEFAULT` + `tracer_release` group (comprehensive)

## Prerequisites
- `DD_API_KEY` secret must be configured in the repo (or available at org level)