### PR TITLE
fix: gracefully skip header_filter and log phases for unrouted requests

### DIFF
--- a/kong/plugins/ddtrace/handler.lua
+++ b/kong/plugins/ddtrace/handler.lua
@@ -285,6 +285,13 @@ local function header_filter(_)
 
     local ctx = kong.ctx.plugin
     if ctx.proxy_span == nil then
+        if not kong.router.get_route() then
+            -- No route matched, so the access phase never ran and no spans were
+            -- created. This is normal for globally-enabled plugins receiving
+            -- unrouted requests (e.g. scanners, direct IP hits).
+            kong.log.debug("no proxy span and no matched route, skipping header_filter phase")
+            return
+        end
         error('proxy span missing during the "header_filter" phase')
     end
 
@@ -352,6 +359,10 @@ local function log(conf)
 
     local ctx = kong.ctx.plugin
     if ctx.request_span == nil then
+        if not kong.router.get_route() then
+            kong.log.debug("no request span and no matched route, skipping log phase")
+            return
+        end
         error("request span is missing during the log phase")
     end
 

--- a/spec/01-unit-tests/09_handler_spec.lua
+++ b/spec/01-unit-tests/09_handler_spec.lua
@@ -1,0 +1,213 @@
+-- Unit tests for the missing-span guard rails added in
+-- "fix: gracefully skip header_filter and log phases for unrouted requests".
+--
+-- The handler relies on several `kong.*` globals that are normally injected
+-- by the Kong runtime. We stub just enough of that surface here to load the
+-- module and exercise the early-return paths in `header_filter` and `log`.
+
+local recorded = {
+    debug = {},
+    err = {},
+}
+
+local function reset_recorded()
+    recorded.debug = {}
+    recorded.err = {}
+end
+
+-- Returns the first entry in `list` containing `needle` as a literal
+-- substring, or `nil` if none match. Using a helper (rather than
+-- `for _, msg in ipairs(list) do assert.is_nil(...) end`) ensures negative
+-- assertions don't pass vacuously when the list is empty -- which is
+-- precisely the case we care about for the unrouted-skip path.
+local function find_containing(list, needle)
+    for _, msg in ipairs(list) do
+        if string.find(msg, needle, 1, true) then
+            return msg
+        end
+    end
+    return nil
+end
+
+-- A no-op router stub that each test can repoint at a function returning
+-- either `nil` (no route matched) or a table (a route did match).
+local current_get_route = function()
+    return nil
+end
+
+_G.kong = {
+    log = {
+        debug = function(msg)
+            table.insert(recorded.debug, tostring(msg))
+        end,
+        info = function(_) end,
+        warn = function(_) end,
+        err = function(...)
+            local parts = { ... }
+            for i, v in ipairs(parts) do
+                parts[i] = tostring(v)
+            end
+            table.insert(recorded.err, table.concat(parts, ""))
+        end,
+        error = function(_) end,
+    },
+    ctx = {
+        plugin = {},
+        shared = {},
+    },
+    router = {
+        get_route = function()
+            return current_get_route()
+        end,
+        get_service = function()
+            return nil
+        end,
+    },
+    node = {
+        get_id = function()
+            return "test-node-id"
+        end,
+    },
+    request = {
+        get_header = function(_) end,
+    },
+    response = {
+        get_status = function()
+            return 200
+        end,
+        get_header = function(_) end,
+    },
+    client = {
+        get_forwarded_ip = function()
+            return "127.0.0.1"
+        end,
+    },
+    service = {
+        request = {
+            set_header = function(_, _) end,
+        },
+    },
+    version = "test",
+    pdk_version = "test",
+    configuration = {
+        role = "traditional",
+        nginx_daemon = "off",
+        database = "off",
+    },
+}
+
+local handler = require("kong.plugins.ddtrace.handler")
+
+describe("handler: missing-span guard for unrouted requests", function()
+    before_each(function()
+        reset_recorded()
+        kong.ctx.plugin = {}
+        current_get_route = function()
+            return nil
+        end
+    end)
+
+    describe("header_filter phase", function()
+        it("returns silently when no span and no matched route", function()
+            -- Plugin enabled globally + scanner / direct-IP request:
+            -- access phase never ran, so ctx.proxy_span is nil, AND no route
+            -- matched. The fix should swallow this case with a debug log.
+            current_get_route = function()
+                return nil
+            end
+
+            handler:header_filter({})
+
+            assert.is_not_nil(
+                find_containing(recorded.debug, "skipping header_filter phase"),
+                "expected a debug log explaining the skip"
+            )
+
+            -- Crucially, the pcall wrapper must NOT have caught a thrown
+            -- error, AND the original error message must not appear anywhere
+            -- (e.g. via kong.log.err). Asserting on the full recorded list
+            -- catches both "no err entries at all" and "err entries exist but
+            -- none mention the missing span".
+            assert.is_nil(
+                find_containing(recorded.err, "tracing error in DatadogTraceHandler"),
+                "no tracing error should be logged when no route matched"
+            )
+            assert.is_nil(
+                find_containing(recorded.err, "proxy span missing"),
+                "the proxy-span-missing error must not be emitted on unrouted requests"
+            )
+        end)
+
+        it("still errors when a route matched but the span is missing", function()
+            -- This is the genuinely unexpected case the original error() was
+            -- written for: a route was matched, so access *should* have run,
+            -- but ctx.proxy_span is somehow nil. The fix must preserve this
+            -- diagnostic.
+            current_get_route = function()
+                return { id = "route-1", name = "mock" }
+            end
+
+            handler:header_filter({})
+
+            assert.is_not_nil(
+                find_containing(recorded.err, "tracing error in DatadogTraceHandler"),
+                "expected the pcall wrapper to log a tracing error"
+            )
+            assert.is_not_nil(
+                find_containing(recorded.err, 'proxy span missing during the "header_filter" phase'),
+                "expected the original proxy-span-missing error to be preserved"
+            )
+
+            assert.is_nil(
+                find_containing(recorded.debug, "skipping header_filter phase"),
+                "should not log the unrouted-skip debug when a route matched"
+            )
+        end)
+    end)
+
+    describe("log phase", function()
+        it("returns silently when no span and no matched route", function()
+            current_get_route = function()
+                return nil
+            end
+
+            handler:log({})
+
+            assert.is_not_nil(
+                find_containing(recorded.debug, "skipping log phase"),
+                "expected a debug log explaining the skip"
+            )
+
+            assert.is_nil(
+                find_containing(recorded.err, "tracing error in DatadogTraceHandler"),
+                "no tracing error should be logged when no route matched"
+            )
+            assert.is_nil(
+                find_containing(recorded.err, "request span is missing"),
+                "the request-span-missing error must not be emitted on unrouted requests"
+            )
+        end)
+
+        it("still errors when a route matched but the span is missing", function()
+            current_get_route = function()
+                return { id = "route-1", name = "mock" }
+            end
+
+            handler:log({})
+
+            assert.is_not_nil(
+                find_containing(recorded.err, "tracing error in DatadogTraceHandler"),
+                "expected the pcall wrapper to log a tracing error"
+            )
+            assert.is_not_nil(
+                find_containing(recorded.err, "request span is missing during the log phase"),
+                "expected the original request-span-missing error to be preserved"
+            )
+
+            assert.is_nil(
+                find_containing(recorded.debug, "skipping log phase"),
+                "should not log the unrouted-skip debug when a route matched"
+            )
+        end)
+    end)
+end)

--- a/spec/02-integration-tests/03-unrouted_spec.lua
+++ b/spec/02-integration-tests/03-unrouted_spec.lua
@@ -1,0 +1,169 @@
+local helpers = require("spec.helpers")
+local pl_path = require("pl.path")
+
+local PLUGIN_NAME = "ddtrace"
+
+-- Walk the given logfile and return the first line for which `predicate`
+-- returns truthy, or `false` if no matching line was found.
+local function find_log_line(logfile, predicate)
+    assert(predicate ~= nil)
+    if pl_path.exists(logfile) and pl_path.getsize(logfile) > 0 then
+        local f = assert(io.open(logfile, "r"))
+        local line = f:read("*line")
+
+        while line do
+            if predicate(line) then
+                f:close()
+                return line
+            end
+            line = f:read("*line")
+        end
+
+        f:close()
+    end
+
+    return false
+end
+
+-- Poll the logfile for up to `timeout` seconds, asserting that no line
+-- matching `predicate` ever appears. Used for negative assertions where
+-- we want to confirm the absence of an error message after an action.
+local function assert_log_absent(logfile, predicate, timeout)
+    timeout = timeout or 5
+    local deadline = ngx.now() + timeout
+    while ngx.now() < deadline do
+        local found = find_log_line(logfile, predicate)
+        if found then
+            error("expected log line to be absent, but found: " .. tostring(found))
+        end
+        ngx.sleep(0.2)
+    end
+end
+
+-- Run the tests for each strategy. Strategies include "postgres" and "off"
+-- which represent the deployment topologies for Kong Gateway.
+for _, strategy in helpers.all_strategies() do
+    describe(PLUGIN_NAME .. ": unrouted requests [#" .. strategy .. "]", function()
+        local client
+
+        lazy_setup(function()
+            local blue_print = helpers.get_db_utils(strategy, nil, { PLUGIN_NAME })
+
+            -- Configure a single route so Kong is functional. The interesting
+            -- case for this test is a request that does NOT match any route.
+            _ = blue_print.routes:insert({
+                paths = { "/mock" },
+            })
+
+            -- Register the plugin globally so it runs on every phase, including
+            -- requests that never match a route.
+            blue_print.plugins:insert({
+                name = PLUGIN_NAME,
+            })
+
+            assert(helpers.start_kong({
+                nginx_conf = "spec/fixtures/custom_nginx.template",
+                plugins = "bundled," .. PLUGIN_NAME,
+                log_level = "debug",
+            }))
+        end)
+
+        lazy_teardown(function()
+            helpers.stop_kong(nil, true)
+        end)
+
+        before_each(function()
+            helpers.clean_logfile()
+            client = helpers.proxy_client()
+        end)
+
+        after_each(function()
+            if client then
+                client:close()
+            end
+        end)
+
+        it("returns 404 without raising tracing errors", function()
+            local res = assert(client:send({
+                method = "GET",
+                path = "/this-path-does-not-match-any-route",
+            }))
+            assert.res_status(404, res)
+
+            local logfile = helpers.get_running_conf().nginx_err_logs
+
+            -- The fix wraps the missing-span error in a "no route" check.
+            -- Neither the pcall'd error nor the wrapper "tracing error"
+            -- message should appear for an unrouted request.
+            assert_log_absent(logfile, function(line)
+                return string.find(line, "tracing error in DatadogTraceHandler", 1, true) ~= nil
+            end)
+            assert_log_absent(logfile, function(line)
+                return string.find(line, 'proxy span missing during the "header_filter" phase', 1, true)
+                    ~= nil
+            end)
+            assert_log_absent(logfile, function(line)
+                return string.find(line, "request span is missing during the log phase", 1, true) ~= nil
+            end)
+        end)
+
+        it("emits debug logs explaining the skipped header_filter and log phases", function()
+            local res = assert(client:send({
+                method = "GET",
+                path = "/another-unrouted-path",
+            }))
+            assert.res_status(404, res)
+
+            local logfile = helpers.get_running_conf().nginx_err_logs
+
+            -- Both phases should log a debug message instead of erroring.
+            helpers.wait_until(function()
+                return find_log_line(logfile, function(line)
+                    return string.find(
+                        line,
+                        "no proxy span and no matched route, skipping header_filter phase",
+                        1,
+                        true
+                    ) ~= nil
+                end) ~= false
+            end, 5)
+
+            helpers.wait_until(function()
+                return find_log_line(logfile, function(line)
+                    return string.find(
+                        line,
+                        "no request span and no matched route, skipping log phase",
+                        1,
+                        true
+                    ) ~= nil
+                end) ~= false
+            end, 5)
+        end)
+
+        it("still traces requests that match a route", function()
+            -- Sanity check: the early-return guards must not interfere with
+            -- the normal routed-request flow. A matched route should produce
+            -- spans (no "skipping" debug messages, no errors) just like before
+            -- the fix.
+            helpers.clean_logfile()
+
+            local res = assert(client:send({
+                method = "GET",
+                path = "/mock",
+            }))
+            assert.res_status(200, res)
+
+            local logfile = helpers.get_running_conf().nginx_err_logs
+
+            assert_log_absent(logfile, function(line)
+                return string.find(line, "skipping header_filter phase", 1, true) ~= nil
+            end)
+            assert_log_absent(logfile, function(line)
+                return string.find(line, "skipping log phase", 1, true) ~= nil
+            end)
+            assert_log_absent(logfile, function(line)
+                return string.find(line, "tracing error in DatadogTraceHandler", 1, true) ~= nil
+            end)
+        end)
+    end)
+end


### PR DESCRIPTION
When the plugin is enabled globally, requests that don't match any route (e.g. scanners, direct IP hits) skip the access phase entirely, so no spans are created. The header_filter and log phases still run for global plugins, causing error() to fire on every unrouted request.

Check kong.router.get_route() before erroring — if no route matched, log at debug level and return early. The error() is preserved for the case where a route was matched but the span is unexpectedly missing.

Resolves https://github.com/DataDog/kong-plugin-ddtrace/issues/106